### PR TITLE
Move @types references from dependencies; fixes #17

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   "author": "HubSpot",
   "license": "ISC",
   "dependencies": {
-    "@types/bluebird": "^3.5.29",
-    "@types/lodash": "^4.14.149",
-    "@types/node": "^12.12.21",
-    "@types/request": "^2.48.4",
     "bluebird": "^3.7.2",
     "bottleneck": "^2.19.5",
     "lodash": "^4.17.19",
     "request": "^2.88.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.29",
+    "@types/lodash": "^4.14.149",
+    "@types/node": "^12.12.21",
+    "@types/request": "^2.48.4",
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-config-standard": "14.1.0",


### PR DESCRIPTION
Moves the `@types/*` dependencies in to `devDependencies` to avoid conflicts in projects that use the library.