### PR TITLE
Remove unsupported BOOLEAN type for card display property

### DIFF
--- a/codegen/crm/extensions/cards/model/cardDisplayProperty.ts
+++ b/codegen/crm/extensions/cards/model/cardDisplayProperty.ts
@@ -65,7 +65,6 @@ export class CardDisplayProperty {
 
 export namespace CardDisplayProperty {
     export enum DataTypeEnum {
-        BOOLEAN = <any> 'BOOLEAN',
         CURRENCY = <any> 'CURRENCY',
         DATE = <any> 'DATE',
         DATETIME = <any> 'DATETIME',


### PR DESCRIPTION
According to the CRM client, `BOOLEAN` type is not supported as a card display property.

![image](https://user-images.githubusercontent.com/1550301/106754488-f201eb80-6624-11eb-806e-665c7fc30ce4.png)