### PR TITLE
TimelineEvent class id should be optional

### DIFF
--- a/codegen/crm/timeline/models/TimelineEvent.ts
+++ b/codegen/crm/timeline/models/TimelineEvent.ts
@@ -53,7 +53,7 @@ export class TimelineEvent {
     /**
     * Identifier for the event. This is optional, and we recommend you do not pass this in. We will create one for you if you omit this. You can also use `{{uuid}}` anywhere in the ID to generate a unique string, guaranteeing uniqueness.
     */
-    'id': string;
+    'id'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 


### PR DESCRIPTION
API doesn't require `id` in `TimelineEvent` class and in fact, the comment recommends not providing one so the service generates one. 