### PR TITLE
chore: remove unused bluebird dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.1.2",
       "license": "ISC",
       "dependencies": {
-        "bluebird": "^3.7.2",
         "bottleneck": "^2.19.5",
         "btoa": "^1.2.1",
         "es6-promise": "^4.2.4",
@@ -19,7 +18,6 @@
         "url-parse": "^1.4.3"
       },
       "devDependencies": {
-        "@types/bluebird": "^3.5.29",
         "@types/jasmine": "^3.6.2",
         "@types/lodash": "^4.14.171",
         "@types/node": "^12.12.21",
@@ -137,12 +135,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
       "dev": true
     },
     "node_modules/@types/jasmine": {
@@ -364,11 +356,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -3281,12 +3268,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "dev": true
-    },
     "@types/jasmine": {
       "version": "3.10.6",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.6.tgz",
@@ -3459,11 +3440,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bottleneck": {
       "version": "2.19.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "HubSpot",
   "license": "ISC",
   "dependencies": {
-    "bluebird": "^3.7.2",
     "bottleneck": "^2.19.5",
     "btoa": "^1.2.1",
     "es6-promise": "^4.2.4",
@@ -27,7 +26,6 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.29",
     "@types/jasmine": "^3.6.2",
     "@types/lodash": "^4.14.171",
     "@types/node": "^12.12.21",


### PR DESCRIPTION
Seems like `bluebird` is unused, so there is no reason to keep it in the dependencies list.