### PR TITLE
feat: add limiter job options

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -214,7 +214,7 @@ export class Client {
     const decorators = new Array()
 
     if (this.config.limiterOptions) {
-      decorators.push(new LimiterDecorator(this.config.limiterOptions))
+      decorators.push(new LimiterDecorator(this.config.limiterOptions, this.config.limiterJobOptions))
     }
 
     if (this.config.numberOfApiCallRetries && this.config.numberOfApiCallRetries > 0) {

--- a/src/configuration/IConfiguration.ts
+++ b/src/configuration/IConfiguration.ts
@@ -8,4 +8,5 @@ export default interface IConfiguration {
   defaultHeaders?: { [key: string]: string }
   numberOfApiCallRetries?: number
   limiterOptions?: Bottleneck.ConstructorOptions
+  limiterJobOptions?: Bottleneck.JobOptions
 }

--- a/src/services/decorators/LimiterDecorator.ts
+++ b/src/services/decorators/LimiterDecorator.ts
@@ -15,7 +15,11 @@ export default class LimiterDecorator implements IDecorator {
       if (!this.limiter) {
         throw new Error('Limiter not defined')
       }
-      this.limiter.schedule(this.limiterJobOptions, () => method(...args))
+      if (this.limiterJobOptions) {
+        return this.limiter.schedule(this.limiterJobOptions, () => method(...args))
+      } else {
+        return this.limiter.wrap(method)
+      }
     }
   }
 }

--- a/src/services/decorators/LimiterDecorator.ts
+++ b/src/services/decorators/LimiterDecorator.ts
@@ -3,15 +3,19 @@ import IDecorator from './IDecorator'
 
 export default class LimiterDecorator implements IDecorator {
   protected limiter: Bottleneck | undefined
+  protected limiterJobOptions: Bottleneck.JobOptions
 
-  public constructor(limiterOptions: Bottleneck.ConstructorOptions) {
+  public constructor(limiterOptions: Bottleneck.ConstructorOptions, limiterJobOptions: Bottleneck.JobOptions = {}) {
     this.limiter = new Bottleneck(limiterOptions)
+    this.limiterJobOptions = limiterJobOptions
   }
 
   public decorate(method: any): (...args: any) => any {
-    if (!this.limiter) {
-      throw new Error('Limiter not defined')
+    return (...args) => {
+      if (!this.limiter) {
+        throw new Error('Limiter not defined')
+      }
+      this.limiter.schedule(this.limiterJobOptions, () => method(...args))
     }
-    return this.limiter.wrap(method)
   }
 }


### PR DESCRIPTION
Bottleneck supports Redis for distributed rate limiting. [Their documentation states](https://github.com/SGrondin/bottleneck#important-considerations-when-clustering):

> It is strongly recommended that you set an expiration (See [Job Options](https://github.com/SGrondin/bottleneck#job-options)) on every job, since that lets the cluster recover from crashed or disconnected clients. Otherwise, a client crashing while executing a job would not be able to tell the cluster to decrease its number of "running" jobs. By using expirations, those lost jobs are automatically cleared after the specified time has passed. Using expirations is essential to keeping a cluster reliable in the face of unpredictable application bugs, network hiccups, and so on.

This was indeed causing frequent issues for us. I've modified the call to limiter slightly to support passing job options.