### PR TITLE
fix: apply decorators inside apiRequest

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -204,10 +204,14 @@ export class Client {
     this.init()
   }
 
-  public async apiRequest(opts: IHttpOptions = {}) {
+  public apiRequest(opts: IHttpOptions = {}) {
     const request = new Request(this.config, opts)
 
-    return await HttpClient.send(request)
+    let { send } = HttpClient
+    for (const decorator of this.getDecorators()) {
+      send = decorator.decorate(send)
+    }
+    return send(request)
   }
 
   protected getDecorators(): IDecorator[] {


### PR DESCRIPTION
* `async`/`await` have no effect as written
* apply decorators to raw `apiRequest` method so treatments like rate limiting are applied.

resolves https://github.com/HubSpot/hubspot-api-nodejs/issues/352