### PR TITLE
Remove console.error message indicating a nondescript status code

### DIFF
--- a/src/services/decorators/RetryDecorator.ts
+++ b/src/services/decorators/RetryDecorator.ts
@@ -36,7 +36,7 @@ export default class RetryDecorator implements IDecorator {
           }
 
           const statusCode: number = get(e, 'code', 0)
-          console.error(statusCode)
+
           if (statusCode >= StatusCodes.MinServerError && statusCode <= StatusCodes.MaxServerError) {
             await this._waitAfterRequestFailure(statusCode, index, this.retryTimeout.INTERNAL_SERVER_ERROR)
             continue


### PR DESCRIPTION
We are using the retry handler, but running into issues with our monitoring.  The retry handler is logging every status code that is not a 2xx message.  The log message doesn't contain any context as to why there is an error.  This logging should be left up to the application.