### PR TITLE
Remove superfluous if statment in applyToMethod

### DIFF
--- a/src/services/ApiDecoratorService.ts
+++ b/src/services/ApiDecoratorService.ts
@@ -47,10 +47,8 @@ export default class ApiDecoratorService {
   }
 
   public applyToMethod(method: any): any {
-    if (this.decorators.length > 0) {
-      for (const decorator of this.decorators) {
-        method = decorator.decorate(method)
-      }
+    for (const decorator of this.decorators) {
+      method = decorator.decorate(method)
     }
 
     return method


### PR DESCRIPTION
This pull request removes the unnecessary if statement in the applyToMethod. The current implementation checks if the this.decorators array has a length greater than 0 before proceeding with the loop. However, since the for loop has no side effects when this.decorators is empty, this check is redundant and can be safely removed.

Changes Made:

   - [x] Removed the if statement that checked for this.decorators.length > 0.