### PR TITLE
Documentation update and proposed test overhaul

### DIFF
--- a/codegen/marketing/forms/apis/FormsApi.ts
+++ b/codegen/marketing/forms/apis/FormsApi.ts
@@ -1,539 +1,1346 @@
 // TODO: better import syntax?
-import {BaseAPIRequestFactory, RequiredError} from './baseapi';
-import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpInfo} from '../http/http';
-import {ObjectSerializer} from '../models/ObjectSerializer';
-import {ApiException} from './exception';
-import { isCodeInRange} from '../util';
-import {SecurityAuthentication} from '../auth/auth';
+import { BaseAPIRequestFactory, RequiredError } from "./baseapi";
+import { Configuration } from "../configuration";
+import {
+  RequestContext,
+  HttpMethod,
+  ResponseContext,
+  HttpInfo,
+} from "../http/http";
+import { ObjectSerializer } from "../models/ObjectSerializer";
+import { ApiException } from "./exception";
+import { isCodeInRange } from "../util";
+import { SecurityAuthentication } from "../auth/auth";
+import { CollectionResponseFormDefinitionBaseForwardPaging } from "../models/CollectionResponseFormDefinitionBaseForwardPaging";
+import { FormDefinitionBase } from "../models/FormDefinitionBase";
+import { FormDefinitionCreateRequestBase } from "../models/FormDefinitionCreateRequestBase";
+import { HubSpotFormDefinition } from "../models/HubSpotFormDefinition";
+import { HubSpotFormDefinitionPatchRequest } from "../models/HubSpotFormDefinitionPatchRequest";
 
-
-import { CollectionResponseFormDefinitionBaseForwardPaging } from '../models/CollectionResponseFormDefinitionBaseForwardPaging';
-import { FormDefinitionBase } from '../models/FormDefinitionBase';
-import { FormDefinitionCreateRequestBase } from '../models/FormDefinitionCreateRequestBase';
-import { HubSpotFormDefinition } from '../models/HubSpotFormDefinition';
-import { HubSpotFormDefinitionPatchRequest } from '../models/HubSpotFormDefinitionPatchRequest';
-
-/**
- * no description
- */
 export class FormsApiRequestFactory extends BaseAPIRequestFactory {
+  /**
+   * Archive a form definition. New submissions will not be accepted, and the form will be permanently deleted after 3 months.
+   * @param {string} formId - The ID of the form to archive.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the response schema:
+   * {
+   *   subCategory: {string}, // A specific category that contains more specific detail about the error.
+   *   context: {Object},      // Context about the error condition.
+   *   correlationId: {string}, // A unique identifier for the request.
+   *   links: {Object},        // A map of link names to associated URIs containing documentation.
+   *   message: {string},      // A human-readable message describing the error and remediation steps.
+   *   category: {string},     // The error category.
+   *   errors: [
+   *     {
+   *       subCategory: {string}, // A specific category containing more specific detail about the error.
+   *       code: {string},        // The status code associated with the error detail.
+   *       in: {string},          // The name of the field or parameter in which the error was found.
+   *       context: {Object},     // Context about the error condition.
+   *       message: {string}      // A human-readable message describing the error and remediation steps.
+   *     }
+   *   ]
+   * }.
+   * @throws {RequiredError} If the formId parameter is null or undefined.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#delete-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D|HubSpot Forms API Documentation}
+   */
+  public async archive(
+    formId: string,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
 
-    /**
-     * Archive a form definition. New submissions will not be accepted and the form definition will be permanently deleted after 3 months.
-     * Archive a form definition
-     * @param formId The ID of the form to archive.
-     */
-    public async archive(formId: string, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
-
-        // verify required parameter 'formId' is not null or undefined
-        if (formId === null || formId === undefined) {
-            throw new RequiredError("FormsApi", "archive", "formId");
-        }
-
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/{formId}'
-            .replace('{' + 'formId' + '}', encodeURIComponent(String(formId)));
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    // verify required parameter 'formId' is not null or undefined
+    if (formId === null || formId === undefined) {
+      throw new RequiredError("FormsApi", "archive", "formId");
     }
 
-    /**
-     * Add a new `hubspot` form
-     * Create a form
-     * @param formDefinitionCreateRequestBase 
-     */
-    public async create(formDefinitionCreateRequestBase: FormDefinitionCreateRequestBase, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/{formId}".replace(
+      "{" + "formId" + "}",
+      encodeURIComponent(String(formId)),
+    );
 
-        // verify required parameter 'formDefinitionCreateRequestBase' is not null or undefined
-        if (formDefinitionCreateRequestBase === null || formDefinitionCreateRequestBase === undefined) {
-            throw new RequiredError("FormsApi", "create", "formDefinitionCreateRequestBase");
-        }
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.DELETE,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
 
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/';
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-
-        // Body Params
-        const contentType = ObjectSerializer.getPreferredMediaType([
-            "application/json"
-        ]);
-        requestContext.setHeaderParam("Content-Type", contentType);
-        const serializedBody = ObjectSerializer.stringify(
-            ObjectSerializer.serialize(formDefinitionCreateRequestBase, "FormDefinitionCreateRequestBase", ""),
-            contentType
-        );
-        requestContext.setBody(serializedBody);
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
     }
 
-    /**
-     * Returns a form based on the form ID provided.
-     * Get a form definition
-     * @param formId The unique identifier of the form
-     * @param archived Whether to return only results that have been archived.
-     */
-    public async getById(formId: string, archived?: boolean, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
-
-        // verify required parameter 'formId' is not null or undefined
-        if (formId === null || formId === undefined) {
-            throw new RequiredError("FormsApi", "getById", "formId");
-        }
-
-
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/{formId}'
-            .replace('{' + 'formId' + '}', encodeURIComponent(String(formId)));
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-        // Query Params
-        if (archived !== undefined) {
-            requestContext.setQueryParam("archived", ObjectSerializer.serialize(archived, "boolean", ""));
-        }
-
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
     }
 
-    /**
-     * Returns a list of forms based on the search filters. By default, it returns the first 20 `hubspot` forms
-     * Get a list of forms
-     * @param after The paging cursor token of the last successfully read resource will be returned as the &#x60;paging.next.after&#x60; JSON property of a paged response containing more results.
-     * @param limit The maximum number of results to display per page.
-     * @param archived Whether to return only results that have been archived.
-     * @param formTypes The form types to be included in the results.
-     */
-    public async getPage(after?: string, limit?: number, archived?: boolean, formTypes?: Array<'hubspot' | 'captured' | 'flow' | 'blog_comment' | 'all'>, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
+    return requestContext;
+  }
 
+  /**
+   * Create a new HubSpot form.
+   * @param {Object} formDefinitionCreateRequestBase - The definition of the form to be created.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the response schema:
+   * {
+   *   formType: {string}, // The type of the form.
+   *   id: {string},       // The unique identifier of the form.
+   *   name: {string},     // The name of the form.
+   *   createdAt: {string}, // The timestamp when the form was created.
+   *   updatedAt: {string}, // The timestamp when the form was last updated.
+   *   archived: {boolean}, // Whether the form is archived.
+   *   archivedAt: {string}, // The timestamp when the form was archived.
+   *   fieldGroups: [
+   *     {
+   *       groupType: {string},       // The type of the field group.
+   *       richTextType: {string},    // The type of rich text included.
+   *       richText: {string},        // A block of rich text or an image.
+   *       fields: [Object]           // The form fields included in the group.
+   *     }
+   *   ],
+   *   configuration: {
+   *     createNewContactForNewEmail: {boolean}, // Whether to create a new contact for a new email.
+   *     editable: {boolean},                  // Whether the form is editable.
+   *     allowLinkToResetKnownValues: {boolean}, // Whether a reset link can be added.
+   *     lifecycleStages: [
+   *       {
+   *         objectTypeId: {string}, // The object type ID.
+   *         value: {string}         // The lifecycle stage value.
+   *       }
+   *     ],
+   *     postSubmitAction: {
+   *       type: {string}, // The action to take after submission.
+   *       value: {string} // The thank-you text or redirection URL.
+   *     },
+   *     language: {string},               // The language of the form.
+   *     prePopulateKnownValues: {boolean}, // Whether known values are pre-populated.
+   *     cloneable: {boolean},              // Whether the form can be cloned.
+   *     notifyContactOwner: {boolean},     // Whether to notify the contact owner.
+   *     recaptchaEnabled: {boolean},       // Whether CAPTCHA is enabled.
+   *     archivable: {boolean}              // Whether the form can be archived.
+   *   },
+   *   displayOptions: {
+   *     renderRawHtml: {boolean}, // Whether the form renders as raw HTML.
+   *     cssClass: {string},       // The CSS class for styling.
+   *     theme: {string},          // The theme for input fields.
+   *     submitButtonText: {string}, // The submit button text.
+   *     style: {
+   *       labelTextSize: {string},          // The label text size.
+   *       legalConsentTextColor: {string}, // The color of the legal consent text.
+   *       fontFamily: {string},            // The font family used.
+   *       legalConsentTextSize: {string},  // The size of the legal consent text.
+   *       backgroundWidth: {string},       // The background width.
+   *       helpTextSize: {string},          // The help text size.
+   *       submitFontColor: {string},       // The submit button font color.
+   *       labelTextColor: {string},        // The label text color.
+   *       submitAlignment: {string},       // The alignment of the submit button.
+   *       submitSize: {string},            // The size of the submit button.
+   *       helpTextColor: {string},         // The help text color.
+   *       submitColor: {string}            // The color of the submit button.
+   *     }
+   *   },
+   *   legalConsentOptions: {
+   *     type: {string}, // The type of legal consent options (e.g., "none").
+   *     legitimateInterest: {
+   *       lawfulBasis: {string}, // The lawful basis for legitimate interest.
+   *       type: {string},         // The type of legitimate interest.
+   *       privacyText: {string}   // The privacy text associated with the option.
+   *     },
+   *     explicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       consentToProcessCheckboxLabel: {string}, // The label for the consent checkbox.
+   *       consentToProcessFooterText: {string},    // The footer text for consent processing.
+   *       type: {string},                      // The type of explicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     },
+   *     implicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       type: {string},                      // The type of implicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     }
+   *   }
+   * }.
+   * @throws {RequiredError} If the `formDefinitionCreateRequestBase` parameter is null or undefined.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#post-%2Fmarketing%2Fv3%2Fforms%2F|HubSpot Forms API Documentation}
+   */
 
+  public async create(
+    formDefinitionCreateRequestBase: FormDefinitionCreateRequestBase,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
 
-
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/';
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-        // Query Params
-        if (after !== undefined) {
-            requestContext.setQueryParam("after", ObjectSerializer.serialize(after, "string", ""));
-        }
-
-        // Query Params
-        if (limit !== undefined) {
-            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int32"));
-        }
-
-        // Query Params
-        if (archived !== undefined) {
-            requestContext.setQueryParam("archived", ObjectSerializer.serialize(archived, "boolean", ""));
-        }
-
-        // Query Params
-        if (formTypes !== undefined) {
-            requestContext.setQueryParam("formTypes", ObjectSerializer.serialize(formTypes, "Array<'hubspot' | 'captured' | 'flow' | 'blog_comment' | 'all'>", ""));
-        }
-
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    // verify required parameter 'formDefinitionCreateRequestBase' is not null or undefined
+    if (
+      formDefinitionCreateRequestBase === null ||
+      formDefinitionCreateRequestBase === undefined
+    ) {
+      throw new RequiredError(
+        "FormsApi",
+        "create",
+        "formDefinitionCreateRequestBase",
+      );
     }
 
-    /**
-     * Update all fields of a hubspot form definition.
-     * Update a form definition
-     * @param formId 
-     * @param hubSpotFormDefinition 
-     */
-    public async replace(formId: string, hubSpotFormDefinition: HubSpotFormDefinition, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/";
 
-        // verify required parameter 'formId' is not null or undefined
-        if (formId === null || formId === undefined) {
-            throw new RequiredError("FormsApi", "replace", "formId");
-        }
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.POST,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
 
+    // Body Params
+    const contentType = ObjectSerializer.getPreferredMediaType([
+      "application/json",
+    ]);
+    requestContext.setHeaderParam("Content-Type", contentType);
+    const serializedBody = ObjectSerializer.stringify(
+      ObjectSerializer.serialize(
+        formDefinitionCreateRequestBase,
+        "FormDefinitionCreateRequestBase",
+        "",
+      ),
+      contentType,
+    );
+    requestContext.setBody(serializedBody);
 
-        // verify required parameter 'hubSpotFormDefinition' is not null or undefined
-        if (hubSpotFormDefinition === null || hubSpotFormDefinition === undefined) {
-            throw new RequiredError("FormsApi", "replace", "hubSpotFormDefinition");
-        }
-
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/{formId}'
-            .replace('{' + 'formId' + '}', encodeURIComponent(String(formId)));
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-
-        // Body Params
-        const contentType = ObjectSerializer.getPreferredMediaType([
-            "application/json"
-        ]);
-        requestContext.setHeaderParam("Content-Type", contentType);
-        const serializedBody = ObjectSerializer.stringify(
-            ObjectSerializer.serialize(hubSpotFormDefinition, "HubSpotFormDefinition", ""),
-            contentType
-        );
-        requestContext.setBody(serializedBody);
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
     }
 
-    /**
-     * Update some of the form definition components
-     * Partially update a form definition
-     * @param formId The ID of the form to update.
-     * @param hubSpotFormDefinitionPatchRequest 
-     */
-    public async update(formId: string, hubSpotFormDefinitionPatchRequest: HubSpotFormDefinitionPatchRequest, _options?: Configuration): Promise<RequestContext> {
-        let _config = _options || this.configuration;
-
-        // verify required parameter 'formId' is not null or undefined
-        if (formId === null || formId === undefined) {
-            throw new RequiredError("FormsApi", "update", "formId");
-        }
-
-
-        // verify required parameter 'hubSpotFormDefinitionPatchRequest' is not null or undefined
-        if (hubSpotFormDefinitionPatchRequest === null || hubSpotFormDefinitionPatchRequest === undefined) {
-            throw new RequiredError("FormsApi", "update", "hubSpotFormDefinitionPatchRequest");
-        }
-
-
-        // Path Params
-        const localVarPath = '/marketing/v3/forms/{formId}'
-            .replace('{' + 'formId' + '}', encodeURIComponent(String(formId)));
-
-        // Make Request Context
-        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PATCH);
-        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-
-
-        // Body Params
-        const contentType = ObjectSerializer.getPreferredMediaType([
-            "application/json"
-        ]);
-        requestContext.setHeaderParam("Content-Type", contentType);
-        const serializedBody = ObjectSerializer.stringify(
-            ObjectSerializer.serialize(hubSpotFormDefinitionPatchRequest, "HubSpotFormDefinitionPatchRequest", ""),
-            contentType
-        );
-        requestContext.setBody(serializedBody);
-
-        let authMethod: SecurityAuthentication | undefined;
-        // Apply auth methods
-        authMethod = _config.authMethods["oauth2"]
-        if (authMethod?.applySecurityAuthentication) {
-            await authMethod?.applySecurityAuthentication(requestContext);
-        }
-        
-        const defaultAuth: SecurityAuthentication | undefined = _options?.authMethods?.default || this.configuration?.authMethods?.default
-        if (defaultAuth?.applySecurityAuthentication) {
-            await defaultAuth?.applySecurityAuthentication(requestContext);
-        }
-
-        return requestContext;
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
     }
 
+    return requestContext;
+  }
+
+  /**
+   * Retrieve a form definition by its ID.
+   * @param {string} formId - The unique identifier of the form.
+   * @param {boolean} [archived] - Whether to return only results that have been archived.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the response schema:
+   * {
+   *   formType: {string}, // The type of the form.
+   *   id: {string},       // The unique identifier of the form.
+   *   name: {string},     // The name of the form.
+   *   createdAt: {string}, // The timestamp when the form was created.
+   *   updatedAt: {string}, // The timestamp when the form was last updated.
+   *   archived: {boolean}, // Whether the form is archived.
+   *   archivedAt: {string}, // The timestamp when the form was archived.
+   *   fieldGroups: [
+   *     {
+   *       groupType: {string},       // The type of the field group.
+   *       richTextType: {string},    // The type of rich text included.
+   *       richText: {string},        // A block of rich text or an image.
+   *       fields: [Object]           // The form fields included in the group.
+   *     }
+   *   ],
+   *   configuration: {
+   *     createNewContactForNewEmail: {boolean}, // Whether to create a new contact for a new email.
+   *     editable: {boolean},                  // Whether the form is editable.
+   *     allowLinkToResetKnownValues: {boolean}, // Whether a reset link can be added.
+   *     lifecycleStages: [
+   *       {
+   *         objectTypeId: {string}, // The object type ID.
+   *         value: {string}         // The lifecycle stage value.
+   *       }
+   *     ],
+   *     postSubmitAction: {
+   *       type: {string}, // The action to take after submission.
+   *       value: {string} // The thank-you text or redirection URL.
+   *     },
+   *     language: {string},               // The language of the form.
+   *     prePopulateKnownValues: {boolean}, // Whether known values are pre-populated.
+   *     cloneable: {boolean},              // Whether the form can be cloned.
+   *     notifyContactOwner: {boolean},     // Whether to notify the contact owner.
+   *     recaptchaEnabled: {boolean},       // Whether CAPTCHA is enabled.
+   *     archivable: {boolean}              // Whether the form can be archived.
+   *   },
+   *   displayOptions: {
+   *     renderRawHtml: {boolean}, // Whether the form renders as raw HTML.
+   *     cssClass: {string},       // The CSS class for styling.
+   *     theme: {string},          // The theme for input fields.
+   *     submitButtonText: {string}, // The submit button text.
+   *     style: {
+   *       labelTextSize: {string},          // The label text size.
+   *       legalConsentTextColor: {string}, // The color of the legal consent text.
+   *       fontFamily: {string},            // The font family used.
+   *       legalConsentTextSize: {string},  // The size of the legal consent text.
+   *       backgroundWidth: {string},       // The background width.
+   *       helpTextSize: {string},          // The help text size.
+   *       submitFontColor: {string},       // The submit button font color.
+   *       labelTextColor: {string},        // The label text color.
+   *       submitAlignment: {string},       // The alignment of the submit button.
+   *       submitSize: {string},            // The size of the submit button.
+   *       helpTextColor: {string},         // The help text color.
+   *       submitColor: {string}            // The color of the submit button.
+   *     }
+   *   },
+   *   legalConsentOptions: {
+   *     type: {string}, // The type of legal consent options (e.g., "none").
+   *     legitimateInterest: {
+   *       lawfulBasis: {string}, // The lawful basis for legitimate interest.
+   *       type: {string},         // The type of legitimate interest.
+   *       privacyText: {string}   // The privacy text associated with the option.
+   *     },
+   *     explicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       consentToProcessCheckboxLabel: {string}, // The label for the consent checkbox.
+   *       consentToProcessFooterText: {string},    // The footer text for consent processing.
+   *       type: {string},                      // The type of explicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     },
+   *     implicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       type: {string},                      // The type of implicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     }
+   *   },
+   *   subCategory: {string},          // A specific category detailing the error.
+   *   context: {Object},              // Context about the error condition.
+   *   correlationId: {string},        // A unique identifier for the request.
+   *   links: {Object},                // A map of links with remediation documentation.
+   *   message: {string},              // A human-readable error message.
+   *   category: {string},             // The error category.
+   *   errors: [
+   *     {
+   *       subCategory: {string},      // Specific sub-category of the error.
+   *       code: {string},             // The status code for the error detail.
+   *       in: {string},               // The parameter in which the error was found.
+   *       context: {Object},          // Context about the error condition.
+   *       message: {string}           // The human-readable error message.
+   *     }
+   *   ]
+   * }.
+   * @throws {RequiredError} If the `formId` parameter is null or undefined.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#get-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D|HubSpot Forms API Documentation}
+   */
+
+  public async getById(
+    formId: string,
+    archived?: boolean,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
+
+    // verify required parameter 'formId' is not null or undefined
+    if (formId === null || formId === undefined) {
+      throw new RequiredError("FormsApi", "getById", "formId");
+    }
+
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/{formId}".replace(
+      "{" + "formId" + "}",
+      encodeURIComponent(String(formId)),
+    );
+
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.GET,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
+
+    // Query Params
+    if (archived !== undefined) {
+      requestContext.setQueryParam(
+        "archived",
+        ObjectSerializer.serialize(archived, "boolean", ""),
+      );
+    }
+
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
+    }
+
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
+    }
+
+    return requestContext;
+  }
+
+  /**
+   * Retrieve a list of forms based on search filters.
+   * By default, returns the first 20 HubSpot forms.
+   * @param {string} [after] - The paging cursor token for the last successfully read resource.
+   * @param {number} [limit=20] - The maximum number of results to display per page.
+   * @param {boolean} [archived] - Whether to return only results that have been archived.
+   * @param {string[]} [formTypes] - The types of forms to include in the results.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the response schema:
+   * {
+   *   paging: {
+   *     next: {
+   *       link: {string}, // The URL for the next page of results.
+   *       after: {string} // The cursor token for the next page of results.
+   *     }
+   *   },
+   *   results: [
+   *     {
+   *       formType: {string},       // The type of the form.
+   *       id: {string},             // The unique identifier of the form.
+   *       name: {string},           // The name of the form.
+   *       createdAt: {string},      // The timestamp when the form was created.
+   *       updatedAt: {string},      // The timestamp when the form was last updated.
+   *       archived: {boolean},      // Whether the form is archived.
+   *       archivedAt: {string},     // The timestamp when the form was archived.
+   *       fieldGroups: [
+   *         {
+   *           groupType: {string},      // The type of the field group.
+   *           richTextType: {string},   // The type of rich text included.
+   *           richText: {string},       // A block of rich text or an image.
+   *           fields: [Object]          // The form fields included in the group.
+   *         }
+   *       ],
+   *       configuration: {
+   *         createNewContactForNewEmail: {boolean}, // Whether to create a new contact for a new email.
+   *         editable: {boolean},                  // Whether the form is editable.
+   *         allowLinkToResetKnownValues: {boolean}, // Whether a reset link can be added.
+   *         lifecycleStages: [
+   *           {
+   *             objectTypeId: {string}, // The object type ID.
+   *             value: {string}         // The lifecycle stage value.
+   *           }
+   *         ],
+   *         postSubmitAction: {
+   *           type: {string}, // The action to take after submission.
+   *           value: {string} // The thank-you text or redirection URL.
+   *         },
+   *         language: {string},               // The language of the form.
+   *         prePopulateKnownValues: {boolean}, // Whether known values are pre-populated.
+   *         cloneable: {boolean},              // Whether the form can be cloned.
+   *         notifyContactOwner: {boolean},     // Whether to notify the contact owner.
+   *         recaptchaEnabled: {boolean},       // Whether CAPTCHA is enabled.
+   *         archivable: {boolean}              // Whether the form can be archived.
+   *       },
+   *       displayOptions: {
+   *         renderRawHtml: {boolean}, // Whether the form renders as raw HTML.
+   *         cssClass: {string},       // The CSS class for styling.
+   *         theme: {string},          // The theme for input fields.
+   *         submitButtonText: {string}, // The submit button text.
+   *         style: {
+   *           labelTextSize: {string},          // The label text size.
+   *           legalConsentTextColor: {string}, // The color of the legal consent text.
+   *           fontFamily: {string},            // The font family used.
+   *           legalConsentTextSize: {string},  // The size of the legal consent text.
+   *           backgroundWidth: {string},       // The background width.
+   *           helpTextSize: {string},          // The help text size.
+   *           submitFontColor: {string},       // The submit button font color.
+   *           labelTextColor: {string},        // The label text color.
+   *           submitAlignment: {string},       // The alignment of the submit button.
+   *           submitSize: {string},            // The size of the submit button.
+   *           helpTextColor: {string},         // The help text color.
+   *           submitColor: {string}            // The color of the submit button.
+   *         }
+   *       },
+   *       legalConsentOptions: {
+   *         type: {string}, // The type of legal consent options (e.g., "none").
+   *         legitimateInterest: {
+   *           lawfulBasis: {string}, // The lawful basis for legitimate interest.
+   *           type: {string},         // The type of legitimate interest.
+   *           privacyText: {string}   // The privacy text associated with the option.
+   *         },
+   *         explicitConsentToProcess: {
+   *           communicationsCheckboxes: [
+   *             {
+   *               subscriptionTypeId: {number}, // The subscription type ID.
+   *               label: {string},              // The main label for the form field.
+   *               required: {boolean}           // Whether the checkbox is required.
+   *             }
+   *           ],
+   *           communicationConsentText: {string}, // The consent text for communication.
+   *           consentToProcessCheckboxLabel: {string}, // The label for the consent checkbox.
+   *           consentToProcessFooterText: {string},    // The footer text for consent processing.
+   *           type: {string},                      // The type of explicit consent.
+   *           privacyText: {string},               // The privacy text.
+   *           consentToProcessText: {string}       // The text for processing consent.
+   *         },
+   *         implicitConsentToProcess: {
+   *           communicationsCheckboxes: [
+   *             {
+   *               subscriptionTypeId: {number}, // The subscription type ID.
+   *               label: {string},              // The main label for the form field.
+   *               required: {boolean}           // Whether the checkbox is required.
+   *             }
+   *           ],
+   *           communicationConsentText: {string}, // The consent text for communication.
+   *           type: {string},                      // The type of implicit consent.
+   *           privacyText: {string},               // The privacy text.
+   *           consentToProcessText: {string}       // The text for processing consent.
+   *         }
+   *       }
+   *     }
+   *   ],
+   *   subCategory: {string},          // A specific category detailing the error.
+   *   context: {Object},              // Context about the error condition.
+   *   correlationId: {string},        // A unique identifier for the request.
+   *   links: {Object},                // A map of links with remediation documentation.
+   *   message: {string},              // A human-readable error message.
+   *   category: {string},             // The error category.
+   *   errors: [
+   *     {
+   *       subCategory: {string},      // Specific sub-category of the error.
+   *       code: {string},             // The status code for the error detail.
+   *       in: {string},               // The parameter in which the error was found.
+   *       context: {Object},          // Context about the error condition.
+   *       message: {string}           // The human-readable error message.
+   *     }
+   *   ]
+   * }.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#get-%2Fmarketing%2Fv3%2Fforms%2F|HubSpot Forms API Documentation}
+   */
+  public async getPage(
+    after?: string,
+    limit?: number,
+    archived?: boolean,
+    formTypes?: Array<"hubspot" | "captured" | "flow" | "blog_comment" | "all">,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
+
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/";
+
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.GET,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
+
+    // Query Params
+    if (after !== undefined) {
+      requestContext.setQueryParam(
+        "after",
+        ObjectSerializer.serialize(after, "string", ""),
+      );
+    }
+
+    // Query Params
+    if (limit !== undefined) {
+      requestContext.setQueryParam(
+        "limit",
+        ObjectSerializer.serialize(limit, "number", "int32"),
+      );
+    }
+
+    // Query Params
+    if (archived !== undefined) {
+      requestContext.setQueryParam(
+        "archived",
+        ObjectSerializer.serialize(archived, "boolean", ""),
+      );
+    }
+
+    // Query Params
+    if (formTypes !== undefined) {
+      requestContext.setQueryParam(
+        "formTypes",
+        ObjectSerializer.serialize(
+          formTypes,
+          "Array<'hubspot' | 'captured' | 'flow' | 'blog_comment' | 'all'>",
+          "",
+        ),
+      );
+    }
+
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
+    }
+
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
+    }
+
+    return requestContext;
+  }
+
+  /**
+   * Update all fields of a HubSpot form definition.
+   * @param {string} formId - The unique identifier of the form to update.
+   * @param {Object} hubSpotFormDefinition - The updated HubSpot form definition.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the request context:
+   * {
+   *   id: {string},             // The unique identifier of the updated form.
+   *   formType: {string},       // The type of the form.
+   *   name: {string},           // The name of the form.
+   *   createdAt: {string},      // The timestamp when the form was created.
+   *   updatedAt: {string},      // The timestamp when the form was last updated.
+   *   archived: {boolean},      // Whether the form is archived.
+   *   archivedAt: {string},     // The timestamp when the form was archived.
+   *   fieldGroups: [
+   *     {
+   *       groupType: {string},      // The type of the field group.
+   *       richTextType: {string},   // The type of rich text included.
+   *       richText: {string},       // A block of rich text or an image.
+   *       fields: [Object]          // The form fields included in the group.
+   *     }
+   *   ],
+   *   configuration: {
+   *     createNewContactForNewEmail: {boolean}, // Whether to create a new contact for a new email.
+   *     editable: {boolean},                  // Whether the form is editable.
+   *     allowLinkToResetKnownValues: {boolean}, // Whether a reset link can be added.
+   *     lifecycleStages: [
+   *       {
+   *         objectTypeId: {string}, // The object type ID.
+   *         value: {string}         // The lifecycle stage value.
+   *       }
+   *     ],
+   *     postSubmitAction: {
+   *       type: {string}, // The action to take after submission.
+   *       value: {string} // The thank-you text or redirection URL.
+   *     },
+   *     language: {string},               // The language of the form.
+   *     prePopulateKnownValues: {boolean}, // Whether known values are pre-populated.
+   *     cloneable: {boolean},              // Whether the form can be cloned.
+   *     notifyContactOwner: {boolean},     // Whether to notify the contact owner.
+   *     recaptchaEnabled: {boolean},       // Whether CAPTCHA is enabled.
+   *     archivable: {boolean}              // Whether the form can be archived.
+   *   },
+   *   displayOptions: {
+   *     renderRawHtml: {boolean}, // Whether the form renders as raw HTML.
+   *     cssClass: {string},       // The CSS class for styling.
+   *     theme: {string},          // The theme for input fields.
+   *     submitButtonText: {string}, // The submit button text.
+   *     style: {
+   *       labelTextSize: {string},          // The label text size.
+   *       legalConsentTextColor: {string}, // The color of the legal consent text.
+   *       fontFamily: {string},            // The font family used.
+   *       legalConsentTextSize: {string},  // The size of the legal consent text.
+   *       backgroundWidth: {string},       // The background width.
+   *       helpTextSize: {string},          // The help text size.
+   *       submitFontColor: {string},       // The submit button font color.
+   *       labelTextColor: {string},        // The label text color.
+   *       submitAlignment: {string},       // The alignment of the submit button.
+   *       submitSize: {string},            // The size of the submit button.
+   *       helpTextColor: {string},         // The help text color.
+   *       submitColor: {string}            // The color of the submit button.
+   *     }
+   *   },
+   *   legalConsentOptions: {
+   *     type: {string}, // The type of legal consent options (e.g., "none").
+   *     legitimateInterest: {
+   *       lawfulBasis: {string}, // The lawful basis for legitimate interest.
+   *       type: {string},         // The type of legitimate interest.
+   *       privacyText: {string}   // The privacy text associated with the option.
+   *     },
+   *     explicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       consentToProcessCheckboxLabel: {string}, // The label for the consent checkbox.
+   *       consentToProcessFooterText: {string},    // The footer text for consent processing.
+   *       type: {string},                      // The type of explicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     },
+   *     implicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       type: {string},                      // The type of implicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     }
+   *   }
+   * }.
+   * @throws {RequiredError} If the `formId` or `hubSpotFormDefinition` parameter is null or undefined.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#put-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D|HubSpot Forms API Documentation}
+   */
+
+  public async replace(
+    formId: string,
+    hubSpotFormDefinition: HubSpotFormDefinition,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
+
+    // verify required parameter 'formId' is not null or undefined
+    if (formId === null || formId === undefined) {
+      throw new RequiredError("FormsApi", "replace", "formId");
+    }
+
+    // verify required parameter 'hubSpotFormDefinition' is not null or undefined
+    if (hubSpotFormDefinition === null || hubSpotFormDefinition === undefined) {
+      throw new RequiredError("FormsApi", "replace", "hubSpotFormDefinition");
+    }
+
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/{formId}".replace(
+      "{" + "formId" + "}",
+      encodeURIComponent(String(formId)),
+    );
+
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.PUT,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
+
+    // Body Params
+    const contentType = ObjectSerializer.getPreferredMediaType([
+      "application/json",
+    ]);
+    requestContext.setHeaderParam("Content-Type", contentType);
+    const serializedBody = ObjectSerializer.stringify(
+      ObjectSerializer.serialize(
+        hubSpotFormDefinition,
+        "HubSpotFormDefinition",
+        "",
+      ),
+      contentType,
+    );
+    requestContext.setBody(serializedBody);
+
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
+    }
+
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
+    }
+
+    return requestContext;
+  }
+
+  /**
+   * Partially update a HubSpot form definition.
+   * @param {string} formId - The unique identifier of the form to update.
+   * @param {Object} hubSpotFormDefinitionPatchRequest - The partial updates to apply to the form definition.
+   * @param {Object} [_options] - Optional configuration overrides.
+   * @returns {Promise<Object>} A promise resolving to the response schema:
+   * {
+   *   id: {string},             // The unique identifier of the updated form.
+   *   formType: {string},       // The type of the form.
+   *   name: {string},           // The name of the form.
+   *   createdAt: {string},      // The timestamp when the form was created.
+   *   updatedAt: {string},      // The timestamp when the form was last updated.
+   *   archived: {boolean},      // Whether the form is archived.
+   *   archivedAt: {string},     // The timestamp when the form was archived.
+   *   fieldGroups: [
+   *     {
+   *       groupType: {string},      // The type of the field group.
+   *       richTextType: {string},   // The type of rich text included.
+   *       richText: {string},       // A block of rich text or an image.
+   *       fields: [Object]          // The form fields included in the group.
+   *     }
+   *   ],
+   *   configuration: {
+   *     createNewContactForNewEmail: {boolean}, // Whether to create a new contact for a new email.
+   *     editable: {boolean},                  // Whether the form is editable.
+   *     allowLinkToResetKnownValues: {boolean}, // Whether a reset link can be added.
+   *     lifecycleStages: [
+   *       {
+   *         objectTypeId: {string}, // The object type ID.
+   *         value: {string}         // The lifecycle stage value.
+   *       }
+   *     ],
+   *     postSubmitAction: {
+   *       type: {string}, // The action to take after submission.
+   *       value: {string} // The thank-you text or redirection URL.
+   *     },
+   *     language: {string},               // The language of the form.
+   *     prePopulateKnownValues: {boolean}, // Whether known values are pre-populated.
+   *     cloneable: {boolean},              // Whether the form can be cloned.
+   *     notifyContactOwner: {boolean},     // Whether to notify the contact owner.
+   *     recaptchaEnabled: {boolean},       // Whether CAPTCHA is enabled.
+   *     archivable: {boolean}              // Whether the form can be archived.
+   *   },
+   *   displayOptions: {
+   *     renderRawHtml: {boolean}, // Whether the form renders as raw HTML.
+   *     cssClass: {string},       // The CSS class for styling.
+   *     theme: {string},          // The theme for input fields.
+   *     submitButtonText: {string}, // The submit button text.
+   *     style: {
+   *       labelTextSize: {string},          // The label text size.
+   *       legalConsentTextColor: {string}, // The color of the legal consent text.
+   *       fontFamily: {string},            // The font family used.
+   *       legalConsentTextSize: {string},  // The size of the legal consent text.
+   *       backgroundWidth: {string},       // The background width.
+   *       helpTextSize: {string},          // The help text size.
+   *       submitFontColor: {string},       // The submit button font color.
+   *       labelTextColor: {string},        // The label text color.
+   *       submitAlignment: {string},       // The alignment of the submit button.
+   *       submitSize: {string},            // The size of the submit button.
+   *       helpTextColor: {string},         // The help text color.
+   *       submitColor: {string}            // The color of the submit button.
+   *     }
+   *   },
+   *   legalConsentOptions: {
+   *     type: {string}, // The type of legal consent options (e.g., "none").
+   *     legitimateInterest: {
+   *       lawfulBasis: {string}, // The lawful basis for legitimate interest.
+   *       type: {string},         // The type of legitimate interest.
+   *       privacyText: {string}   // The privacy text associated with the option.
+   *     },
+   *     explicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       consentToProcessCheckboxLabel: {string}, // The label for the consent checkbox.
+   *       consentToProcessFooterText: {string},    // The footer text for consent processing.
+   *       type: {string},                      // The type of explicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     },
+   *     implicitConsentToProcess: {
+   *       communicationsCheckboxes: [
+   *         {
+   *           subscriptionTypeId: {number}, // The subscription type ID.
+   *           label: {string},              // The main label for the form field.
+   *           required: {boolean}           // Whether the checkbox is required.
+   *         }
+   *       ],
+   *       communicationConsentText: {string}, // The consent text for communication.
+   *       type: {string},                      // The type of implicit consent.
+   *       privacyText: {string},               // The privacy text.
+   *       consentToProcessText: {string}       // The text for processing consent.
+   *     }
+   *   }
+   * }.
+   * @throws {RequiredError} If the `formId` or `hubSpotFormDefinitionPatchRequest` parameter is null or undefined.
+   * @see {@link https://developers.hubspot.com/beta-docs/reference/api/marketing/forms#patch-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D|HubSpot Forms API Documentation}
+   */
+
+  public async update(
+    formId: string,
+    hubSpotFormDefinitionPatchRequest: HubSpotFormDefinitionPatchRequest,
+    _options?: Configuration,
+  ): Promise<RequestContext> {
+    let _config = _options || this.configuration;
+
+    // verify required parameter 'formId' is not null or undefined
+    if (formId === null || formId === undefined) {
+      throw new RequiredError("FormsApi", "update", "formId");
+    }
+
+    // verify required parameter 'hubSpotFormDefinitionPatchRequest' is not null or undefined
+    if (
+      hubSpotFormDefinitionPatchRequest === null ||
+      hubSpotFormDefinitionPatchRequest === undefined
+    ) {
+      throw new RequiredError(
+        "FormsApi",
+        "update",
+        "hubSpotFormDefinitionPatchRequest",
+      );
+    }
+
+    // Path Params
+    const localVarPath = "/marketing/v3/forms/{formId}".replace(
+      "{" + "formId" + "}",
+      encodeURIComponent(String(formId)),
+    );
+
+    // Make Request Context
+    const requestContext = _config.baseServer.makeRequestContext(
+      localVarPath,
+      HttpMethod.PATCH,
+    );
+    requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8");
+
+    // Body Params
+    const contentType = ObjectSerializer.getPreferredMediaType([
+      "application/json",
+    ]);
+    requestContext.setHeaderParam("Content-Type", contentType);
+    const serializedBody = ObjectSerializer.stringify(
+      ObjectSerializer.serialize(
+        hubSpotFormDefinitionPatchRequest,
+        "HubSpotFormDefinitionPatchRequest",
+        "",
+      ),
+      contentType,
+    );
+    requestContext.setBody(serializedBody);
+
+    let authMethod: SecurityAuthentication | undefined;
+    // Apply auth methods
+    authMethod = _config.authMethods["oauth2"];
+    if (authMethod?.applySecurityAuthentication) {
+      await authMethod?.applySecurityAuthentication(requestContext);
+    }
+
+    const defaultAuth: SecurityAuthentication | undefined =
+      _options?.authMethods?.default ||
+      this.configuration?.authMethods?.default;
+    if (defaultAuth?.applySecurityAuthentication) {
+      await defaultAuth?.applySecurityAuthentication(requestContext);
+    }
+
+    return requestContext;
+  }
 }
 
 export class FormsApiResponseProcessor {
-
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to archive
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async archiveWithHttpInfo(response: ResponseContext): Promise<HttpInfo<void >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("204", response.httpStatusCode)) {
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
-
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: void = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "void", ""
-            ) as void;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+  /**
+   * Unwraps the actual response sent by the server from the response context and deserializes the response content
+   * to the expected objects for a request to archive.
+   * @param {Object} response - Response returned by the server for a request to archive.
+   * @returns {Promise<Object>} A promise resolving to an HttpInfo object:
+   * {
+   *   statusCode: {number},    // The HTTP status code of the response.
+   *   headers: {Object},       // The headers of the response.
+   *   body: {string|Buffer},   // The raw body content of the response.
+   *   parsedBody: {void|Error} // The deserialized response content.
+   * }.
+   * @throws {ApiException<Error>} If the response code is 0 or indicates an error.
+   * @throws {ApiException} If the response code was not in [200, 299].
+   */
+  public async archiveWithHttpInfo(
+    response: ResponseContext,
+  ): Promise<HttpInfo<void>> {
+    const contentType = ObjectSerializer.normalizeMediaType(
+      response.headers["content-type"],
+    );
+    if (isCodeInRange("204", response.httpStatusCode)) {
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        undefined,
+      );
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+      const body: Error = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "Error",
+        "",
+      ) as Error;
+      throw new ApiException<Error>(
+        response.httpStatusCode,
+        "An error occurred.",
+        body,
+        response.headers,
+      );
     }
 
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to create
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async createWithHttpInfo(response: ResponseContext): Promise<HttpInfo<FormDefinitionBase >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("201", response.httpStatusCode)) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
-
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+    // Work around for missing responses in specification, e.g., for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+      const body: void = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "void",
+        "",
+      ) as void;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
     }
 
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to getById
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async getByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<FormDefinitionBase >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
+    throw new ApiException<string | Buffer | undefined>(
+      response.httpStatusCode,
+      "Unknown API Status Code!",
+      await response.getBodyAsAny(),
+      response.headers,
+    );
+  }
 
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+/**
+ * Unwraps the actual response sent by the server from the response context and deserializes the response content
+ * to the expected objects for a "create" request.
+ *
+ * @param {ResponseContext} response - The response returned by the server for a "create" request.
+   * @returns {Promise<Object>} A promise resolving to an HttpInfo object:
+   * {
+   *   statusCode: {number},          // The HTTP status code of the response.
+   *   headers: {Object},             // The headers of the response.
+   *   body: {string|Buffer},         // The raw body content of the response.
+   *   parsedBody: {FormDefinitionBase|Error} // The deserialized response content.
+   * }.
+   * @t
+ * @throws {ApiException<Error>} If the response code is `0` or indicates a generic error.
+ * @throws {ApiException<string | Buffer | undefined>} If the response code is outside the expected range [200, 299].
+ */
+public async createWithHttpInfo(response: ResponseContext): Promise<HttpInfo<FormDefinitionBase>> {
+    const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
+    if (isCodeInRange("201", response.httpStatusCode)) {
+        const body: FormDefinitionBase = ObjectSerializer.deserialize(
+            ObjectSerializer.parse(await response.body.text(), contentType),
+            "FormDefinitionBase", ""
+        ) as FormDefinitionBase;
+        return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+        const body: Error = ObjectSerializer.deserialize(
+            ObjectSerializer.parse(await response.body.text(), contentType),
+            "Error", ""
+        ) as Error;
+        throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
     }
 
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to getPage
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async getPageWithHttpInfo(response: ResponseContext): Promise<HttpInfo<CollectionResponseFormDefinitionBaseForwardPaging >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: CollectionResponseFormDefinitionBaseForwardPaging = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "CollectionResponseFormDefinitionBaseForwardPaging", ""
-            ) as CollectionResponseFormDefinitionBaseForwardPaging;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
-
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: CollectionResponseFormDefinitionBaseForwardPaging = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "CollectionResponseFormDefinitionBaseForwardPaging", ""
-            ) as CollectionResponseFormDefinitionBaseForwardPaging;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+    // Workaround for missing responses in specification, e.g., for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+        const body: FormDefinitionBase = ObjectSerializer.deserialize(
+            ObjectSerializer.parse(await response.body.text(), contentType),
+            "FormDefinitionBase", ""
+        ) as FormDefinitionBase;
+        return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
     }
 
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to replace
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async replaceWithHttpInfo(response: ResponseContext): Promise<HttpInfo<FormDefinitionBase >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
+    throw new ApiException<string | Buffer | undefined>(
+        response.httpStatusCode,
+        "Unknown API Status Code!",
+        await response.getBodyAsAny(),
+        response.headers
+    );
+}
 
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+  /**
+   * Unwraps the actual response sent by the server from the response context and deserializes the response content
+   * to the expected objects for a request to getById.
+   * @param {Object} response - Response returned by the server for a request to getById.
+   * @returns {Promise<Object>} A promise resolving to an HttpInfo object:
+   * {
+   *   statusCode: {number},          // The HTTP status code of the response.
+   *   headers: {Object},             // The headers of the response.
+   *   body: {string|Buffer},         // The raw body content of the response.
+   *   parsedBody: {FormDefinitionBase|Error} // The deserialized response content.
+   * }.
+   * @throws {ApiException<Error>} If the response code is 0 or indicates an error.
+   * @throws {ApiException} If the response code was not in [200, 299].
+   */
+  public async getByIdWithHttpInfo(
+    response: ResponseContext,
+  ): Promise<HttpInfo<FormDefinitionBase>> {
+    const contentType = ObjectSerializer.normalizeMediaType(
+      response.headers["content-type"],
+    );
+    if (isCodeInRange("200", response.httpStatusCode)) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+      const body: Error = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "Error",
+        "",
+      ) as Error;
+      throw new ApiException<Error>(
+        response.httpStatusCode,
+        "An error occurred.",
+        body,
+        response.headers,
+      );
     }
 
-    /**
-     * Unwraps the actual response sent by the server from the response context and deserializes the response content
-     * to the expected objects
-     *
-     * @params response Response returned by the server for a request to update
-     * @throws ApiException if the response code was not in [200, 299]
-     */
-     public async updateWithHttpInfo(response: ResponseContext): Promise<HttpInfo<FormDefinitionBase >> {
-        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("0", response.httpStatusCode)) {
-            const body: Error = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "Error", ""
-            ) as Error;
-            throw new ApiException<Error>(response.httpStatusCode, "An error occurred.", body, response.headers);
-        }
-
-        // Work around for missing responses in specification, e.g. for petstore.yaml
-        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            const body: FormDefinitionBase = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "FormDefinitionBase", ""
-            ) as FormDefinitionBase;
-            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-
-        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+    // Work around for missing responses in specification, e.g., for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
     }
 
+    throw new ApiException<string | Buffer | undefined>(
+      response.httpStatusCode,
+      "Unknown API Status Code!",
+      await response.getBodyAsAny(),
+      response.headers,
+    );
+  }
+
+  /**
+   * Unwraps the actual response sent by the server from the response context and deserializes the response content
+   * to the expected objects for getPageWithHttpInfo.
+   *
+   * @async
+   * @param {ResponseContext} response - Response returned by the server for a request to getPage.
+   * @returns {Promise<HttpInfo<CollectionResponseFormDefinitionBaseForwardPaging>>} - The deserialized HTTP information with the response body.
+   * @throws {ApiException<Error>} If the response code is 0 or indicates an error.
+   * @throws {ApiException<string | Buffer | undefined>} If the response status code is unknown.
+   */
+  public async getPageWithHttpInfo(
+    response: ResponseContext,
+  ): Promise<HttpInfo<CollectionResponseFormDefinitionBaseForwardPaging>> {
+    const contentType = ObjectSerializer.normalizeMediaType(
+      response.headers["content-type"],
+    );
+    if (isCodeInRange("200", response.httpStatusCode)) {
+      const body: CollectionResponseFormDefinitionBaseForwardPaging =
+        ObjectSerializer.deserialize(
+          ObjectSerializer.parse(await response.body.text(), contentType),
+          "CollectionResponseFormDefinitionBaseForwardPaging",
+          "",
+        ) as CollectionResponseFormDefinitionBaseForwardPaging;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+      const body: Error = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "Error",
+        "",
+      ) as Error;
+      throw new ApiException<Error>(
+        response.httpStatusCode,
+        "An error occurred.",
+        body,
+        response.headers,
+      );
+    }
+
+    // Work around for missing responses in specification, e.g. for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+      const body: CollectionResponseFormDefinitionBaseForwardPaging =
+        ObjectSerializer.deserialize(
+          ObjectSerializer.parse(await response.body.text(), contentType),
+          "CollectionResponseFormDefinitionBaseForwardPaging",
+          "",
+        ) as CollectionResponseFormDefinitionBaseForwardPaging;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+
+    throw new ApiException<string | Buffer | undefined>(
+      response.httpStatusCode,
+      "Unknown API Status Code!",
+      await response.getBodyAsAny(),
+      response.headers,
+    );
+  }
+
+  /**
+   * Unwraps the actual response sent by the server from the response context and deserializes the response content
+   * to the expected objects for replaceWithHttpInfo.
+   *
+   * @async
+   * @param {ResponseContext} response - Response returned by the server for a request to replace.
+   * @returns {Promise<HttpInfo<FormDefinitionBase>>} - The deserialized HTTP information with the response body.
+   * @throws {ApiException<Error>} If the response code is 0 or indicates an error.
+   * @throws {ApiException<string | Buffer | undefined>} If the response status code is unknown.
+   */
+  public async replaceWithHttpInfo(
+    response: ResponseContext,
+  ): Promise<HttpInfo<FormDefinitionBase>> {
+    const contentType = ObjectSerializer.normalizeMediaType(
+      response.headers["content-type"],
+    );
+    if (isCodeInRange("200", response.httpStatusCode)) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+      const body: Error = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "Error",
+        "",
+      ) as Error;
+      throw new ApiException<Error>(
+        response.httpStatusCode,
+        "An error occurred.",
+        body,
+        response.headers,
+      );
+    }
+
+    // Work around for missing responses in specification, e.g. for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+
+    throw new ApiException<string | Buffer | undefined>(
+      response.httpStatusCode,
+      "Unknown API Status Code!",
+      await response.getBodyAsAny(),
+      response.headers,
+    );
+  }
+
+  /**
+   * Unwraps the actual response sent by the server from the response context and deserializes the response content
+   * to the expected objects for updateWithHttpInfo.
+   *
+   * @async
+   * @param {ResponseContext} response - Response returned by the server for a request to update.
+   * @returns {Promise<HttpInfo<FormDefinitionBase>>} - The deserialized HTTP information with the response body.
+   * @throws {ApiException<Error>} If the response code is 0 or indicates an error.
+   * @throws {ApiException<string | Buffer | undefined>} If the response status code is unknown.
+   */
+  public async updateWithHttpInfo(
+    response: ResponseContext,
+  ): Promise<HttpInfo<FormDefinitionBase>> {
+    const contentType = ObjectSerializer.normalizeMediaType(
+      response.headers["content-type"],
+    );
+    if (isCodeInRange("200", response.httpStatusCode)) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+    if (isCodeInRange("0", response.httpStatusCode)) {
+      const body: Error = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "Error",
+        "",
+      ) as Error;
+      throw new ApiException<Error>(
+        response.httpStatusCode,
+        "An error occurred.",
+        body,
+        response.headers,
+      );
+    }
+
+    // Work around for missing responses in specification, e.g. for petstore.yaml
+    if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+      const body: FormDefinitionBase = ObjectSerializer.deserialize(
+        ObjectSerializer.parse(await response.body.text(), contentType),
+        "FormDefinitionBase",
+        "",
+      ) as FormDefinitionBase;
+      return new HttpInfo(
+        response.httpStatusCode,
+        response.headers,
+        response.body,
+        body,
+      );
+    }
+
+    throw new ApiException<string | Buffer | undefined>(
+      response.httpStatusCode,
+      "Unknown API Status Code!",
+      await response.getBodyAsAny(),
+      response.headers,
+    );
+  }
 }

--- a/codegen/marketing/forms/apis/baseapi.ts
+++ b/codegen/marketing/forms/apis/baseapi.ts
@@ -1,8 +1,11 @@
 import { Configuration } from '../configuration'
 
 /**
+ * A collection of supported collection formats for API requests.
  *
  * @export
+ * @constant
+ * @type {{ csv: string; ssv: string; tsv: string; pipes: string }}
  */
 export const COLLECTION_FORMATS = {
     csv: ",",
@@ -11,26 +14,45 @@ export const COLLECTION_FORMATS = {
     pipes: "|",
 };
 
-
 /**
+ * A base class for API request factories that provides access to configuration settings.
  *
  * @export
- * @class BaseAPI
+ * @class BaseAPIRequestFactory
  */
 export class BaseAPIRequestFactory {
 
+    /**
+     * Creates an instance of BaseAPIRequestFactory.
+     *
+     * @param {Configuration} configuration - The configuration object for the API requests.
+     */
     constructor(protected configuration: Configuration) {
     }
-};
+}
 
 /**
+ * Represents an error thrown when a required parameter is missing during an API call.
  *
  * @export
  * @class RequiredError
  * @extends {Error}
  */
 export class RequiredError extends Error {
+    /**
+     * The name of the error.
+     *
+     * @type {"RequiredError"}
+     */
     name: "RequiredError" = "RequiredError";
+
+    /**
+     * Creates an instance of RequiredError.
+     *
+     * @param {string} api - The name of the API where the error occurred.
+     * @param {string} method - The name of the method where the error occurred.
+     * @param {string} field - The name of the missing field causing the error.
+     */
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/codegen/marketing/forms/apis/exception.ts
+++ b/codegen/marketing/forms/apis/exception.ts
@@ -1,15 +1,34 @@
 /**
- * Represents an error caused by an api call i.e. it has attributes for a HTTP status code
- * and the returned body object.
+ * Represents an error caused by an API call, including attributes for an HTTP status code,
+ * the returned body object, and the response headers.
  *
- * Example
- * API returns a ErrorMessageObject whenever HTTP status code is not in [200, 299]
- * => ApiException(404, someErrorMessageObject)
+ * Example:
+ * If the API returns an error message object when the HTTP status code is not in [200, 299]:
+ * => new ApiException(404, "Not Found", someErrorMessageObject, { "Content-Type": "application/json" })
  *
+ * @template T - The type of the response body.
+ * @extends {Error}
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
-        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+    /**
+     * Creates an instance of ApiException.
+     *
+     * @param {number} code - The HTTP status code of the response.
+     * @param {string} message - A descriptive message for the error.
+     * @param {T} body - The response body object returned by the API.
+     * @param {{ [key: string]: string }} headers - The headers returned in the API response.
+     */
+    public constructor(
+        public code: number,
+        message: string,
+        public body: T,
+        public headers: { [key: string]: string }
+    ) {
+        super(
+            "HTTP-Code: " + code +
+            "\nMessage: " + message +
+            "\nBody: " + JSON.stringify(body) +
+            "\nHeaders: " + JSON.stringify(headers)
+        );
     }
 }

--- a/test/spec/marketing/forms/forms.spec.ts.proposed
+++ b/test/spec/marketing/forms/forms.spec.ts.proposed
@@ -1,0 +1,659 @@
+import { Client } from '../../../../index';
+import { RequiredError } from '../../../../api'; // Adjust the import path as needed
+import * as dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config();
+
+describe('FormsApi - archive method', () => {
+    let client: any;
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should throw RequiredError if ARCHIVE_FORM_ID is null', async (done) => {
+        const formId = null; // Simulating null value
+        try {
+            await client.archive(formId as unknown as string);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.archive.');
+        }
+        done();
+    });
+
+    it('should throw RequiredError if ARCHIVE_FORM_ID is undefined', async (done) => {
+        const formId = undefined; // Simulating undefined value
+        try {
+            await client.archive(formId as unknown as string);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.archive.');
+        }
+        done();
+    });
+
+    it('should send a DELETE request to the correct endpoint with ARCHIVE_FORM_ID', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        const formId = process.env.ARCHIVE_FORM_ID;
+        if (!formId) {
+            fail('ARCHIVE_FORM_ID is not defined in the environment variables');
+        }
+
+        client['configuration'] = mockConfiguration;
+
+        const requestContext = await client.archive(formId as string);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            `/marketing/v3/forms/${formId}`,
+            'DELETE'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Accept',
+            'application/json, */*;q=0.8'
+        );
+
+        expect(
+            mockConfiguration.authMethods.oauth2.applySecurityAuthentication
+        ).toHaveBeenCalledWith(requestContext);
+
+        done();
+    });
+});
+
+describe('FormsApi - create method', () => {
+    let client: any;
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should throw RequiredError if formDefinitionCreateRequestBase is null', async (done) => {
+        const formDefinitionCreateRequestBase = null; // Simulating null value
+        try {
+            await client.create(formDefinitionCreateRequestBase as unknown as any);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe(
+                'Required parameter formDefinitionCreateRequestBase was null or undefined when calling FormsApi.create.'
+            );
+        }
+        done();
+    });
+
+    it('should throw RequiredError if formDefinitionCreateRequestBase is undefined', async (done) => {
+        const formDefinitionCreateRequestBase = undefined; // Simulating undefined value
+        try {
+            await client.create(formDefinitionCreateRequestBase as unknown as any);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe(
+                'Required parameter formDefinitionCreateRequestBase was null or undefined when calling FormsApi.create.'
+            );
+        }
+        done();
+    });
+
+    it('should send a POST request to the correct endpoint with valid formDefinitionCreateRequestBase', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setBody: jasmine.createSpy('setBody'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        const formDefinitionCreateRequestBase = JSON.parse(process.env.FORM_DEFINITION_CREATE_REQUEST || '{}');
+        if (!formDefinitionCreateRequestBase || Object.keys(formDefinitionCreateRequestBase).length === 0) {
+            fail('FORM_DEFINITION_CREATE_REQUEST is not defined or invalid in the environment variables');
+        }
+
+        client['configuration'] = mockConfiguration;
+
+        const requestContext = await client.create(formDefinitionCreateRequestBase);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            '/marketing/v3/forms/',
+            'POST'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Accept',
+            'application/json, */*;q=0.8'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Content-Type',
+            'application/json'
+        );
+
+        expect(requestContext.setBody).toHaveBeenCalledWith(
+            JSON.stringify(formDefinitionCreateRequestBase)
+        );
+
+        expect(
+            mockConfiguration.authMethods.oauth2.applySecurityAuthentication
+        ).toHaveBeenCalledWith(requestContext);
+
+        done();
+    });
+});
+
+describe('FormsApi - getById method', () => {
+    let client: any;
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should throw RequiredError if formId is null', async (done) => {
+        const formId = null; // Simulating null value
+        try {
+            await client.getById(formId as unknown as string);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.getById.');
+        }
+        done();
+    });
+
+    it('should throw RequiredError if formId is undefined', async (done) => {
+        const formId = undefined; // Simulating undefined value
+        try {
+            await client.getById(formId as unknown as string);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.getById.');
+        }
+        done();
+    });
+
+    it('should send a GET request to the correct endpoint with GET_FORM_BY_ID', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setQueryParam: jasmine.createSpy('setQueryParam'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        const formId = process.env.GET_FORM_BY_ID;
+        if (!formId) {
+            fail('GET_FORM_BY_ID is not defined in the environment variables');
+        }
+
+        const archived = true; // Simulate querying for archived forms
+
+        client['configuration'] = mockConfiguration;
+
+        const requestContext = await client.getById(formId, archived);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            `/marketing/v3/forms/${formId}`,
+            'GET'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Accept',
+            'application/json, */*;q=0.8'
+        );
+
+        expect(requestContext.setQueryParam).toHaveBeenCalledWith(
+            'archived',
+            'true'
+        );
+
+        expect(
+            mockConfiguration.authMethods.oauth2.applySecurityAuthentication
+        ).toHaveBeenCalledWith(requestContext);
+
+        done();
+    });
+});
+
+describe('FormsApi - getPage method', () => {
+    let client: any;
+
+    const mockFirstPageResponse = {
+        paging: {
+            next: {
+                after: 'mockCursorToken', // Simulated cursor token from the first response
+            },
+        },
+        results: [
+            {
+                id: '123',
+                name: 'First Page Form',
+            },
+        ],
+    };
+
+    const mockSecondPageResponse = {
+        paging: {
+            next: {
+                after: 'secondMockCursorToken', // Simulated cursor token for the next page
+            },
+        },
+        results: [
+            {
+                id: '456',
+                name: 'Second Page Form',
+            },
+        ],
+    };
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should handle pagination by dynamically using the after token from the response', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setQueryParam: jasmine.createSpy('setQueryParam'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        client['configuration'] = mockConfiguration;
+
+        // Mock the getPage method to simulate responses
+        spyOn(client, 'getPage').and.callFake((after) => {
+            if (!after) {
+                return Promise.resolve(mockFirstPageResponse); // First page
+            }
+            if (after === 'mockCursorToken') {
+                return Promise.resolve(mockSecondPageResponse); // Second page
+            }
+            return Promise.resolve({ paging: {}, results: [] }); // No more pages
+        });
+
+        const archived = process.env.ARCHIVED === 'true'; // Parse as boolean
+        const formTypes = JSON.parse(process.env.FORM_TYPES || '[]'); // Parse JSON string
+        const limit = 20; // Default limit for the API
+
+        // Fetch the first page
+        const firstPageResponse = await client.getPage(undefined, limit, archived, formTypes);
+
+        expect(client.getPage).toHaveBeenCalledWith(undefined, limit, archived, formTypes);
+
+        const firstPageAfter = firstPageResponse.paging?.next?.after;
+        expect(firstPageAfter).toBe('mockCursorToken');
+
+        // Fetch the second page using the after token from the first response
+        const secondPageResponse = await client.getPage(firstPageAfter, limit, archived, formTypes);
+
+        expect(client.getPage).toHaveBeenCalledWith('mockCursorToken', limit, archived, formTypes);
+
+        const secondPageAfter = secondPageResponse.paging?.next?.after;
+        expect(secondPageAfter).toBe('secondMockCursorToken');
+
+        done();
+    });
+
+    it('should send a GET request with default parameters when no after token is provided', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setQueryParam: jasmine.createSpy('setQueryParam'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        client['configuration'] = mockConfiguration;
+
+        const archived = process.env.ARCHIVED === 'true'; // Parse as boolean
+        const formTypes = JSON.parse(process.env.FORM_TYPES || '[]'); // Parse JSON string
+        const limit = 20; // Default limit for the API
+
+        await client.getPage(undefined, limit, archived, formTypes);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            '/marketing/v3/forms/',
+            'GET'
+        );
+
+        expect(mockConfiguration.baseServer.makeRequestContext().setQueryParam).toHaveBeenCalledWith('limit', '20');
+        expect(mockConfiguration.baseServer.makeRequestContext().setQueryParam).toHaveBeenCalledWith(
+            'archived',
+            archived.toString()
+        );
+        expect(mockConfiguration.baseServer.makeRequestContext().setQueryParam).toHaveBeenCalledWith(
+            'formTypes',
+            JSON.stringify(formTypes)
+        );
+
+        done();
+    });
+});
+
+describe('FormsApi - replace method', () => {
+    let client: any;
+
+    const mockHubSpotFormDefinition = {
+        id: process.env.REPLACE_FORM_ID,
+        formType: 'REGULAR',
+        name: 'Updated Form',
+        configuration: {
+            createNewContactForNewEmail: true,
+            editable: true,
+        },
+        displayOptions: {
+            submitButtonText: 'Submit',
+        },
+        fieldGroups: [],
+    };
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should throw RequiredError if formId is null', async (done) => {
+        const formId = null; // Simulate null value
+        try {
+            await client.replace(formId as unknown as string, mockHubSpotFormDefinition);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.replace.');
+        }
+        done();
+    });
+
+    it('should throw RequiredError if hubSpotFormDefinition is null', async (done) => {
+        const formId = process.env.REPLACE_FORM_ID;
+        if (!formId) {
+            fail('REPLACE_FORM_ID is not defined in the environment variables');
+        }
+        const hubSpotFormDefinition = null; // Simulate null value
+        try {
+            await client.replace(formId, hubSpotFormDefinition as unknown as any);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe(
+                'Required parameter hubSpotFormDefinition was null or undefined when calling FormsApi.replace.'
+            );
+        }
+        done();
+    });
+
+    it('should send a PUT request to update the form definition', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setBody: jasmine.createSpy('setBody'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        const formId = process.env.REPLACE_FORM_ID;
+        if (!formId) {
+            fail('REPLACE_FORM_ID is not defined in the environment variables');
+        }
+
+        client['configuration'] = mockConfiguration;
+
+        const requestContext = await client.replace(formId, mockHubSpotFormDefinition);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            `/marketing/v3/forms/${formId}`,
+            'PUT'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Accept',
+            'application/json, */*;q=0.8'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Content-Type',
+            'application/json'
+        );
+
+        expect(requestContext.setBody).toHaveBeenCalledWith(
+            JSON.stringify(mockHubSpotFormDefinition)
+        );
+
+        expect(
+            mockConfiguration.authMethods.oauth2.applySecurityAuthentication
+        ).toHaveBeenCalledWith(requestContext);
+
+        done();
+    });
+});
+
+describe('FormsApi - update method', () => {
+    let client: any;
+
+    const mockHubSpotFormDefinitionPatchRequest = {
+        name: 'Partially Updated Form',
+        configuration: {
+            editable: false,
+        },
+    };
+
+    beforeEach(() => {
+        client = new Client().marketing.forms;
+    });
+
+    it('should throw RequiredError if formId is null', async (done) => {
+        const formId = null; // Simulate null value
+        try {
+            await client.update(formId as unknown as string, mockHubSpotFormDefinitionPatchRequest);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe('Required parameter formId was null or undefined when calling FormsApi.update.');
+        }
+        done();
+    });
+
+    it('should throw RequiredError if hubSpotFormDefinitionPatchRequest is null', async (done) => {
+        const formId = process.env.UPDATE_PARTIAL_FORM_ID;
+        if (!formId) {
+            fail('UPDATE_PARTIAL_FORM_ID is not defined in the environment variables');
+        }
+        const hubSpotFormDefinitionPatchRequest = null; // Simulate null value
+        try {
+            await client.update(formId, hubSpotFormDefinitionPatchRequest as unknown as any);
+            fail('Expected a RequiredError to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequiredError);
+            expect(error.message).toBe(
+                'Required parameter hubSpotFormDefinitionPatchRequest was null or undefined when calling FormsApi.update.'
+            );
+        }
+        done();
+    });
+
+    it('should send a PATCH request to partially update the form definition', async (done) => {
+        const mockConfiguration = {
+            baseServer: {
+                makeRequestContext: jasmine.createSpy('makeRequestContext').and.returnValue({
+                    setHeaderParam: jasmine.createSpy('setHeaderParam'),
+                    setBody: jasmine.createSpy('setBody'),
+                }),
+            },
+            authMethods: {
+                oauth2: {
+                    applySecurityAuthentication: jasmine.createSpy('applySecurityAuthentication'),
+                },
+            },
+        };
+
+        const formId = process.env.UPDATE_PARTIAL_FORM_ID;
+        if (!formId) {
+            fail('UPDATE_PARTIAL_FORM_ID is not defined in the environment variables');
+        }
+
+        client['configuration'] = mockConfiguration;
+
+        const requestContext = await client.update(formId, mockHubSpotFormDefinitionPatchRequest);
+
+        expect(mockConfiguration.baseServer.makeRequestContext).toHaveBeenCalledWith(
+            `/marketing/v3/forms/${formId}`,
+            'PATCH'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Accept',
+            'application/json, */*;q=0.8'
+        );
+
+        expect(requestContext.setHeaderParam).toHaveBeenCalledWith(
+            'Content-Type',
+            'application/json'
+        );
+
+        expect(requestContext.setBody).toHaveBeenCalledWith(
+            JSON.stringify(mockHubSpotFormDefinitionPatchRequest)
+        );
+
+        expect(
+            mockConfiguration.authMethods.oauth2.applySecurityAuthentication
+        ).toHaveBeenCalledWith(requestContext);
+
+        done();
+    });
+});
+
+describe('FormsApiResponseProcessor - archiveWithHttpInfo method', () => {
+    let responseProcessor: FormsApiResponseProcessor;
+
+    beforeEach(() => {
+        responseProcessor = new FormsApiResponseProcessor();
+    });
+
+    it('should return an HttpInfo object for a 204 No Content response', async (done) => {
+        const mockResponse = {
+            httpStatusCode: 204,
+            headers: { 'content-type': 'application/json' },
+            body: null,
+        };
+
+        const result = await responseProcessor.archiveWithHttpInfo(mockResponse);
+
+        expect(result.statusCode).toBe(204);
+        expect(result.headers).toEqual(mockResponse.headers);
+        expect(result.body).toBe(mockResponse.body);
+        expect(result.parsedBody).toBeUndefined(); // Expect parsedBody to be undefined for a 204 response
+
+        done();
+    });
+
+    it('should throw an ApiException for a response code of 0', async (done) => {
+        const mockResponse = {
+            httpStatusCode: 0,
+            headers: { 'content-type': 'application/json' },
+            body: {
+                text: async () => JSON.stringify({ message: 'Network error occurred' }),
+            },
+        };
+
+        try {
+            await responseProcessor.archiveWithHttpInfo(mockResponse);
+            fail('Expected an ApiException to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(ApiException);
+            expect(error.message).toBe('An error occurred.');
+            expect(error.statusCode).toBe(0);
+            expect(error.body).toEqual({ message: 'Network error occurred' });
+            expect(error.headers).toEqual(mockResponse.headers);
+        }
+
+        done();
+    });
+
+    it('should return an HttpInfo object for a 2xx success response', async (done) => {
+        const mockResponse = {
+            httpStatusCode: 200,
+            headers: { 'content-type': 'application/json' },
+            body: {
+                text: async () => JSON.stringify({}),
+            },
+        };
+
+        const result = await responseProcessor.archiveWithHttpInfo(mockResponse);
+
+        expect(result.statusCode).toBe(200);
+        expect(result.headers).toEqual(mockResponse.headers);
+        expect(result.body).toBe(mockResponse.body);
+        expect(result.parsedBody).toBeUndefined(); // Expect parsedBody to be void for 2xx responses with no body
+
+        done();
+    });
+
+    it('should throw an ApiException for non-2xx status codes outside 204', async (done) => {
+        const mockResponse = {
+            httpStatusCode: 400,
+            headers: { 'content-type': 'application/json' },
+            body: {
+                text: async () => JSON.stringify({ error: 'Bad Request' }),
+            },
+        };
+
+        try {
+            await responseProcessor.archiveWithHttpInfo(mockResponse);
+            fail('Expected an ApiException to be thrown');
+        } catch (error) {
+            expect(error).toBeInstanceOf(ApiException);
+            expect(error.message).toBe('Unknown API Status Code!');
+            expect(error.statusCode).toBe(400);
+            expect(error.body).toEqual({ error: 'Bad Request' });
+            expect(error.headers).toEqual(mockResponse.headers);
+        }
+
+        done();
+    });
+});


### PR DESCRIPTION
This PR was created partially in response to #485, but also due to @demandlab concerns that this package does not meet quality standards.

As a proof of concept, I have done the following:
* Updated `codegen/marketing/forms/apis/FormsApi.ts` with verbose JSDoc markup based on the contents available at [HubSpot's API documentation for forms](https://developers.hubspot.com/beta-docs/reference/api/marketing/forms)
* Updated supporting file documentation at `codegen/marketing/forms/apis/baseapi.ts` and `codegen/marketing/forms/apis/exception.ts`
* Added a proposed overhauled test suite for the forms API; however, because all current Jasmine tests are mocks and not running to live HubSpot instances to verify, additional work will need to be done to fully support enhanced testing. 

Please let me know if this level of verbosity is requested in the package and we will continue to commit extended JSDoc notation for the portions of the package we are using. Likewise, if there is greater community interest in overhauling unit tests to be more comprehensive, we would welcome any collaboration.
