### PR TITLE
Fix https status 201 throwing error

### DIFF
--- a/codegen/marketing/events/apis/AttendanceSubscriberStateChangesApi.ts
+++ b/codegen/marketing/events/apis/AttendanceSubscriberStateChangesApi.ts
@@ -173,7 +173,7 @@ export class AttendanceSubscriberStateChangesApiResponseProcessor {
      */
      public async recordByContactEmailsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<BatchResponseSubscriberEmailResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
+        if (isCodeInRange("20X", response.httpStatusCode)) {
             const body: BatchResponseSubscriberEmailResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "BatchResponseSubscriberEmailResponse", ""
@@ -209,7 +209,7 @@ export class AttendanceSubscriberStateChangesApiResponseProcessor {
      */
      public async recordByContactIdsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<BatchResponseSubscriberVidResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
+        if (isCodeInRange("20X", response.httpStatusCode)) {
             const body: BatchResponseSubscriberVidResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "BatchResponseSubscriberVidResponse", ""


### PR DESCRIPTION
The API client throws an error, even though the http code received is 201. See example error:

```
ApiException [Error]: HTTP-Code: 201
Message: An error occurred.
Body: {"status":"COMPLETE","results":[{"vid":123456789}],"startedAt":"2025-01-24T12:55:11.104Z","completedAt":"2025-01-24T12:55:11.140Z"}
```

This fix makes http status 20X be a success instead of an error.