### PR TITLE
fix: replace node-fetch with native fetch

### DIFF
--- a/codegen/automation/actions/http/isomorphic-fetch.ts
+++ b/codegen/automation/actions/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/audit_logs/http/isomorphic-fetch.ts
+++ b/codegen/cms/audit_logs/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/blogs/authors/http/isomorphic-fetch.ts
+++ b/codegen/cms/blogs/authors/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/blogs/blog_posts/http/isomorphic-fetch.ts
+++ b/codegen/cms/blogs/blog_posts/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/blogs/tags/http/isomorphic-fetch.ts
+++ b/codegen/cms/blogs/tags/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/domains/http/isomorphic-fetch.ts
+++ b/codegen/cms/domains/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/hubdb/http/isomorphic-fetch.ts
+++ b/codegen/cms/hubdb/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/pages/http/isomorphic-fetch.ts
+++ b/codegen/cms/pages/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/site_search/http/isomorphic-fetch.ts
+++ b/codegen/cms/site_search/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/source_code/http/isomorphic-fetch.ts
+++ b/codegen/cms/source_code/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/cms/url_redirects/http/isomorphic-fetch.ts
+++ b/codegen/cms/url_redirects/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/communication_preferences/http/isomorphic-fetch.ts
+++ b/codegen/communication_preferences/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/conversations/visitor_identification/http/isomorphic-fetch.ts
+++ b/codegen/conversations/visitor_identification/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/associations/http/isomorphic-fetch.ts
+++ b/codegen/crm/associations/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/associations/schema/http/isomorphic-fetch.ts
+++ b/codegen/crm/associations/schema/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/associations/v4/http/isomorphic-fetch.ts
+++ b/codegen/crm/associations/v4/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/associations/v4/schema/http/isomorphic-fetch.ts
+++ b/codegen/crm/associations/v4/schema/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/commerce/invoices/http/isomorphic-fetch.ts
+++ b/codegen/crm/commerce/invoices/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/companies/http/isomorphic-fetch.ts
+++ b/codegen/crm/companies/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/contacts/http/isomorphic-fetch.ts
+++ b/codegen/crm/contacts/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/deals/http/isomorphic-fetch.ts
+++ b/codegen/crm/deals/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/exports/http/isomorphic-fetch.ts
+++ b/codegen/crm/exports/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/extensions/calling/http/isomorphic-fetch.ts
+++ b/codegen/crm/extensions/calling/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/extensions/cards/http/isomorphic-fetch.ts
+++ b/codegen/crm/extensions/cards/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/extensions/videoconferencing/http/isomorphic-fetch.ts
+++ b/codegen/crm/extensions/videoconferencing/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/imports/http/isomorphic-fetch.ts
+++ b/codegen/crm/imports/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/line_items/http/isomorphic-fetch.ts
+++ b/codegen/crm/line_items/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/lists/http/isomorphic-fetch.ts
+++ b/codegen/crm/lists/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/calls/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/calls/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/communications/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/communications/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/deal_splits/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/deal_splits/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/emails/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/emails/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/feedback_submissions/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/feedback_submissions/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/goals/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/goals/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/leads/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/leads/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/meetings/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/meetings/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/notes/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/notes/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/postal_mail/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/postal_mail/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/tasks/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/tasks/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/objects/taxes/http/isomorphic-fetch.ts
+++ b/codegen/crm/objects/taxes/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/owners/http/isomorphic-fetch.ts
+++ b/codegen/crm/owners/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/pipelines/http/isomorphic-fetch.ts
+++ b/codegen/crm/pipelines/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/products/http/isomorphic-fetch.ts
+++ b/codegen/crm/products/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/properties/http/isomorphic-fetch.ts
+++ b/codegen/crm/properties/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/quotes/http/isomorphic-fetch.ts
+++ b/codegen/crm/quotes/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/schemas/http/isomorphic-fetch.ts
+++ b/codegen/crm/schemas/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/tickets/http/isomorphic-fetch.ts
+++ b/codegen/crm/tickets/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/crm/timeline/http/isomorphic-fetch.ts
+++ b/codegen/crm/timeline/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/events/http/isomorphic-fetch.ts
+++ b/codegen/events/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/events/send/http/isomorphic-fetch.ts
+++ b/codegen/events/send/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/files/http/isomorphic-fetch.ts
+++ b/codegen/files/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/marketing/emails/http/isomorphic-fetch.ts
+++ b/codegen/marketing/emails/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/marketing/events/http/isomorphic-fetch.ts
+++ b/codegen/marketing/events/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/marketing/forms/http/isomorphic-fetch.ts
+++ b/codegen/marketing/forms/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/marketing/transactional/http/isomorphic-fetch.ts
+++ b/codegen/marketing/transactional/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/oauth/http/isomorphic-fetch.ts
+++ b/codegen/oauth/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/settings/business_units/http/isomorphic-fetch.ts
+++ b/codegen/settings/business_units/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/settings/users/http/isomorphic-fetch.ts
+++ b/codegen/settings/users/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/codegen/webhooks/http/isomorphic-fetch.ts
+++ b/codegen/webhooks/http/isomorphic-fetch.ts
@@ -1,29 +1,21 @@
 import {HttpLibrary, RequestContext, ResponseContext} from './http';
 import { from, Observable } from '../rxjsStub';
-import fetch from "node-fetch";
+import { sendBufferedRequest } from '../../../src/services/http/Transport';
 
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-        let method = request.getHttpMethod().toString();
-        let body = request.getBody();
-
-        const resultPromise = fetch(request.getUrl(), {
-            method: method,
-            body: body as any,
+        const resultPromise = sendBufferedRequest(request.getUrl(), {
+            method: request.getHttpMethod().toString(),
+            body: request.getBody(),
             headers: request.getHeaders(),
             agent: request.getAgent(),
-        }).then((resp: any) => {
-            const headers: { [name: string]: string } = {};
-            resp.headers.forEach((value: string, name: string) => {
-              headers[name] = value;
-            });
-
+        }).then((response) => {
             const body = {
-              text: () => resp.text(),
-              binary: () => resp.buffer()
+              text: () => response.text(),
+              binary: () => response.binary()
             };
-            return new ResponseContext(resp.status, headers, body);
+            return new ResponseContext(response.status, response.headers, body);
         });
 
         return from<Promise<ResponseContext>>(resultPromise);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "@types/node": "*",
-        "@types/node-fetch": "^2.6.13",
         "bottleneck": "^2.19.5",
         "es6-promise": "^4.2.4",
         "form-data": "^4.0.4",
-        "lodash.merge": "^4.6.2",
-        "node-fetch": "^2.6.0"
+        "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -572,16 +570,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3653,26 +3641,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4816,12 +4784,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5101,22 +5063,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,11 @@
   "author": "HubSpot",
   "license": "ISC",
   "dependencies": {
-    "@types/node-fetch": "^2.6.13",
     "@types/node": "*",
     "bottleneck": "^2.19.5",
     "es6-promise": "^4.2.4",
     "form-data": "^4.0.4",
-    "lodash.merge": "^4.6.2",
-    "node-fetch": "^2.6.0"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/services/http/HttpClient.ts
+++ b/src/services/http/HttpClient.ts
@@ -1,8 +1,8 @@
-import fetch from 'node-fetch'
 import { Request } from './Request'
+import { sendFetchRequest } from './Transport'
 
 export class HttpClient {
   public static async send(request: Request) {
-    return await fetch(request.getUrl(), request.getSendData())
+    return await sendFetchRequest(request.getUrl(), request.getSendData())
   }
 }

--- a/src/services/http/Transport.ts
+++ b/src/services/http/Transport.ts
@@ -1,0 +1,229 @@
+import FormData from 'form-data'
+import * as http from 'http'
+import * as https from 'https'
+import { URLSearchParams } from 'url'
+
+type HeaderMap = Record<string, string>
+type RequestUrl = string | URL
+
+interface PipeableBody {
+  on(event: string, listener: (...args: unknown[]) => void): unknown
+  pipe(destination: NodeJS.WritableStream): NodeJS.WritableStream
+}
+
+export interface IHttpTransportOptions {
+  method?: string
+  headers?: HeaderMap
+  body?: unknown
+  agent?: http.Agent | https.Agent
+}
+
+export interface IBufferedResponse {
+  status: number
+  headers: HeaderMap
+  text(): Promise<string>
+  binary(): Promise<Buffer>
+}
+
+export async function sendFetchRequest(url: RequestUrl, options: IHttpTransportOptions): Promise<Response> {
+  // Native fetch supports WHATWG FormData, but this SDK's public upload contract
+  // uses the npm form-data stream; without this path, multipart uploads are
+  // stringified as "[object FormData]" and break existing callers.
+  if (isFormDataBody(options.body)) {
+    const response = await sendNodeRequest(url, options)
+    const responseBody = shouldOmitResponseBody(response.status) ? null : await response.binary()
+
+    return new Response(responseBody, {
+      headers: response.headers,
+      status: response.status,
+    })
+  }
+
+  return await fetch(url, buildRequestInit(options))
+}
+
+export async function sendBufferedRequest(url: RequestUrl, options: IHttpTransportOptions): Promise<IBufferedResponse> {
+  if (options.agent) {
+    return await sendNodeRequest(url, options)
+  }
+
+  const response = await sendFetchRequest(url, options)
+  return createBufferedResponse(response.status, getHeadersFromFetchResponse(response), async () => {
+    return Buffer.from(await response.arrayBuffer())
+  })
+}
+
+function buildRequestInit(options: IHttpTransportOptions): RequestInit & { duplex?: 'half' } {
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    method: options.method,
+    headers: normalizeHeaders(options.headers, options.body),
+  }
+
+  if (options.body !== undefined) {
+    requestInit.body = options.body as RequestInit['body']
+  }
+
+  if (isPipeableBody(options.body)) {
+    requestInit.duplex = 'half'
+  }
+
+  return requestInit
+}
+
+function normalizeHeaders(headers: HeaderMap | undefined, body: unknown): HeaderMap | undefined {
+  if (isFormDataBody(body)) {
+    return mergeHeaders(headers, body.getHeaders())
+  }
+
+  if (!headers) {
+    return undefined
+  }
+
+  return { ...headers }
+}
+
+function mergeHeaders(headers: HeaderMap | undefined, nextHeaders: HeaderMap): HeaderMap {
+  const mergedHeaders = headers ? { ...headers } : {}
+
+  for (const [nextHeaderName, nextHeaderValue] of Object.entries(nextHeaders)) {
+    const existingHeaderName = Object.keys(mergedHeaders).find(
+      (headerName) => headerName.toLowerCase() === nextHeaderName.toLowerCase(),
+    )
+
+    if (existingHeaderName) {
+      delete mergedHeaders[existingHeaderName]
+    }
+
+    mergedHeaders[nextHeaderName] = nextHeaderValue
+  }
+
+  return mergedHeaders
+}
+
+function isFormDataBody(body: unknown): body is FormData {
+  return body instanceof FormData
+}
+
+function isPipeableBody(body: unknown): body is PipeableBody {
+  return typeof body === 'object' && body !== null && 'pipe' in body && 'on' in body
+}
+
+async function sendNodeRequest(url: RequestUrl, options: IHttpTransportOptions): Promise<IBufferedResponse> {
+  const targetUrl = typeof url === 'string' ? new URL(url) : url
+  const requestHeaders = normalizeHeaders(options.headers, options.body)
+  const requestBody = serializeBody(options.body)
+  const transport = targetUrl.protocol === 'https:' ? https : http
+
+  return await new Promise<IBufferedResponse>((resolve, reject) => {
+    const request = transport.request(
+      targetUrl,
+      {
+        agent: options.agent,
+        headers: requestHeaders,
+        method: options.method,
+      },
+      (response) => {
+        const chunks: Buffer[] = []
+
+        response.on('data', (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        })
+
+        response.on('end', () => {
+          const body = Buffer.concat(chunks)
+          resolve(
+            createBufferedResponse(response.statusCode ?? 0, getHeadersFromNodeResponse(response), async () => body),
+          )
+        })
+
+        response.on('error', reject)
+      },
+    )
+
+    request.on('error', reject)
+
+    if (requestBody === undefined) {
+      request.end()
+      return
+    }
+
+    if (isPipeableBody(requestBody)) {
+      requestBody.on('error', reject)
+      requestBody.pipe(request)
+      return
+    }
+
+    request.end(requestBody)
+  })
+}
+
+function serializeBody(body: unknown): string | Buffer | PipeableBody | undefined {
+  if (body === undefined) {
+    return undefined
+  }
+
+  if (typeof body === 'string' || Buffer.isBuffer(body) || isPipeableBody(body)) {
+    return body
+  }
+
+  if (body instanceof URLSearchParams) {
+    return body.toString()
+  }
+
+  throw new TypeError('Unsupported HTTP request body for Node transport.')
+}
+
+function getHeadersFromFetchResponse(response: Response): HeaderMap {
+  const headers: HeaderMap = {}
+
+  response.headers.forEach((value, name) => {
+    headers[name] = value
+  })
+
+  return headers
+}
+
+function getHeadersFromNodeResponse(response: http.IncomingMessage): HeaderMap {
+  const headers: HeaderMap = {}
+
+  for (const [name, value] of Object.entries(response.headers)) {
+    if (value === undefined) {
+      continue
+    }
+
+    headers[name] = Array.isArray(value) ? value.join(', ') : value
+  }
+
+  return headers
+}
+
+function createBufferedResponse(
+  status: number,
+  headers: HeaderMap,
+  getBody: () => Promise<Buffer>,
+): IBufferedResponse {
+  let bodyPromise: Promise<Buffer> | undefined
+
+  const readBody = async () => {
+    if (!bodyPromise) {
+      bodyPromise = getBody()
+    }
+
+    return await bodyPromise
+  }
+
+  return {
+    status,
+    headers,
+    async binary() {
+      return await readBody()
+    },
+    async text() {
+      return (await readBody()).toString()
+    },
+  }
+}
+
+function shouldOmitResponseBody(status: number): boolean {
+  return status === 101 || status === 204 || status === 205 || status === 304
+}

--- a/test/unit/httpTransport.spec.ts
+++ b/test/unit/httpTransport.spec.ts
@@ -1,0 +1,195 @@
+import * as http from 'http'
+import FormData from 'form-data'
+import { Client } from '../../index'
+import { HttpMethod, RequestContext } from '../../codegen/crm/contacts/http/http'
+import { IsomorphicFetchHttpLibrary } from '../../codegen/crm/contacts/http/isomorphic-fetch'
+import { createConfiguration } from '../../codegen/files/configuration'
+import { FilesApiRequestFactory } from '../../codegen/files/apis/FilesApi'
+import { IsomorphicFetchHttpLibrary as FilesHttpLibrary } from '../../codegen/files/http/isomorphic-fetch'
+import { ServerConfiguration } from '../../codegen/files/servers'
+
+interface ICapturedRequest {
+  method: string
+  url: string
+  headers: http.IncomingHttpHeaders
+  body: Buffer
+}
+
+describe('HTTP transport', () => {
+  it('sends apiRequest JSON bodies through native fetch', async () => {
+    let capturedRequest: ICapturedRequest | undefined
+    const server = await createServer(async (request, response) => {
+      capturedRequest = request
+      response.statusCode = 201
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({ ok: true }))
+    })
+
+    try {
+      const client = new Client({ accessToken: 'test-token' })
+      const response = await client.apiRequest({
+        method: 'POST',
+        overlapUrl: `${server.baseUrl}/json?foo=bar`,
+        body: { hello: 'world' },
+      })
+
+      expect(response.status).toBe(201)
+      expect(await response.json()).toEqual({ ok: true })
+      expect(capturedRequest).toBeDefined()
+      expect(capturedRequest!.method).toBe('POST')
+      expect(capturedRequest!.url).toBe('/json?foo=bar')
+      expect(capturedRequest!.headers.authorization).toBe('Bearer test-token')
+      expect(String(capturedRequest!.headers['content-type'])).toContain('application/json')
+      expect(capturedRequest!.body.toString()).toBe(JSON.stringify({ hello: 'world' }))
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('preserves multipart apiRequest uploads with the form-data package', async () => {
+    let capturedRequest: ICapturedRequest | undefined
+    const server = await createServer(async (request, response) => {
+      capturedRequest = request
+      response.statusCode = 204
+      response.end()
+    })
+
+    try {
+      const formData = new FormData()
+      formData.append('field', 'value')
+      formData.append('file', Buffer.from('payload'), { filename: 'hello.txt', contentType: 'text/plain' })
+
+      const client = new Client()
+      const response = await client.apiRequest({
+        method: 'POST',
+        overlapUrl: `${server.baseUrl}/upload`,
+        body: formData,
+        defaultJson: false,
+      })
+
+      expect(response.status).toBe(204)
+      expect(capturedRequest).toBeDefined()
+      expect(String(capturedRequest!.headers['content-type'])).toContain('multipart/form-data; boundary=')
+      expect(capturedRequest!.body.toString()).toContain('name="field"')
+      expect(capturedRequest!.body.toString()).toContain('value')
+      expect(capturedRequest!.body.toString()).toContain('filename="hello.txt"')
+      expect(capturedRequest!.body.toString()).toContain('payload')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('returns generated ResponseContext bodies through native fetch', async () => {
+    let capturedRequest: ICapturedRequest | undefined
+    const server = await createServer(async (request, response) => {
+      capturedRequest = request
+      response.statusCode = 202
+      response.setHeader('content-type', 'application/octet-stream')
+      response.end(Buffer.from('generated-response'))
+    })
+
+    try {
+      const requestContext = new RequestContext(`${server.baseUrl}/generated`, HttpMethod.POST)
+      requestContext.setHeaderParam('X-Test', '1')
+      requestContext.setBody('payload')
+
+      const response = await new IsomorphicFetchHttpLibrary().send(requestContext).toPromise()
+
+      expect(response.httpStatusCode).toBe(202)
+      expect(capturedRequest).toBeDefined()
+      expect(capturedRequest!.method).toBe('POST')
+      expect(capturedRequest!.headers['x-test']).toBe('1')
+      expect(capturedRequest!.body.toString()).toBe('payload')
+      expect(await response.body.text()).toBe('generated-response')
+      expect((await response.body.binary()).toString()).toBe('generated-response')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('supports generated multipart uploads when a custom httpAgent is configured', async () => {
+    let capturedRequest: ICapturedRequest | undefined
+    const server = await createServer(async (request, response) => {
+      capturedRequest = request
+      response.statusCode = 200
+      response.end('ok')
+    })
+
+    try {
+      const configuration = createConfiguration({
+        baseServer: new ServerConfiguration(server.baseUrl, {}),
+      })
+      const requestContext = await new FilesApiRequestFactory(configuration).upload(
+        { data: Buffer.from('payload'), name: 'hello.txt' },
+        undefined,
+        '/folder',
+        'hello.txt',
+      )
+      requestContext.setAgent(new http.Agent({ keepAlive: true }))
+
+      const response = await new FilesHttpLibrary().send(requestContext).toPromise()
+
+      expect(response.httpStatusCode).toBe(200)
+      expect(capturedRequest).toBeDefined()
+      expect(capturedRequest!.method).toBe('POST')
+      expect(capturedRequest!.url).toBe('/files/v3/files')
+      expect(String(capturedRequest!.headers['content-type'])).toContain('multipart/form-data; boundary=')
+      expect(capturedRequest!.body.toString()).toContain('filename="hello.txt"')
+      expect(capturedRequest!.body.toString()).toContain('name="folderPath"')
+      expect(capturedRequest!.body.toString()).toContain('/folder')
+      expect(capturedRequest!.body.toString()).toContain('payload')
+      expect(await response.body.text()).toBe('ok')
+    } finally {
+      await server.close()
+    }
+  })
+})
+
+async function createServer(
+  handler: (request: ICapturedRequest, response: http.ServerResponse) => Promise<void> | void,
+): Promise<{ baseUrl: string; close(): Promise<void> }> {
+  const server = http.createServer(async (request, response) => {
+    const bodyChunks: Buffer[] = []
+
+    request.on('data', (chunk) => {
+      bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    })
+
+    request.on('end', async () => {
+      await handler(
+        {
+          body: Buffer.concat(bodyChunks),
+          headers: request.headers,
+          method: request.method ?? 'GET',
+          url: request.url ?? '/',
+        },
+        response,
+      )
+    })
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start test server.')
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+    },
+  }
+}


### PR DESCRIPTION
Replaces `node-fetch` with Node native fetch in the SDK transport layer

closes #670 #680 #565, maybe more