### PR TITLE
fix(types): allow Node Readable in HttpFile.data

### DIFF
--- a/codegen/automation/actions/http/http.ts
+++ b/codegen/automation/actions/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/audit_logs/http/http.ts
+++ b/codegen/cms/audit_logs/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/blogs/authors/http/http.ts
+++ b/codegen/cms/blogs/authors/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/blogs/blog_posts/http/http.ts
+++ b/codegen/cms/blogs/blog_posts/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/blogs/tags/http/http.ts
+++ b/codegen/cms/blogs/tags/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/domains/http/http.ts
+++ b/codegen/cms/domains/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/hubdb/http/http.ts
+++ b/codegen/cms/hubdb/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/pages/http/http.ts
+++ b/codegen/cms/pages/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/site_search/http/http.ts
+++ b/codegen/cms/site_search/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/source_code/http/http.ts
+++ b/codegen/cms/source_code/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/cms/url_redirects/http/http.ts
+++ b/codegen/cms/url_redirects/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/communication_preferences/http/http.ts
+++ b/codegen/communication_preferences/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/conversations/visitor_identification/http/http.ts
+++ b/codegen/conversations/visitor_identification/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/associations/http/http.ts
+++ b/codegen/crm/associations/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/associations/schema/http/http.ts
+++ b/codegen/crm/associations/schema/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/associations/v4/http/http.ts
+++ b/codegen/crm/associations/v4/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/associations/v4/schema/http/http.ts
+++ b/codegen/crm/associations/v4/schema/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/commerce/invoices/http/http.ts
+++ b/codegen/crm/commerce/invoices/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/companies/http/http.ts
+++ b/codegen/crm/companies/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/contacts/http/http.ts
+++ b/codegen/crm/contacts/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/deals/http/http.ts
+++ b/codegen/crm/deals/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/exports/http/http.ts
+++ b/codegen/crm/exports/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/extensions/calling/http/http.ts
+++ b/codegen/crm/extensions/calling/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/extensions/cards/http/http.ts
+++ b/codegen/crm/extensions/cards/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/extensions/videoconferencing/http/http.ts
+++ b/codegen/crm/extensions/videoconferencing/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/imports/http/http.ts
+++ b/codegen/crm/imports/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/line_items/http/http.ts
+++ b/codegen/crm/line_items/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/lists/http/http.ts
+++ b/codegen/crm/lists/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/calls/http/http.ts
+++ b/codegen/crm/objects/calls/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/communications/http/http.ts
+++ b/codegen/crm/objects/communications/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/deal_splits/http/http.ts
+++ b/codegen/crm/objects/deal_splits/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/emails/http/http.ts
+++ b/codegen/crm/objects/emails/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/feedback_submissions/http/http.ts
+++ b/codegen/crm/objects/feedback_submissions/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/goals/http/http.ts
+++ b/codegen/crm/objects/goals/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/http/http.ts
+++ b/codegen/crm/objects/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/leads/http/http.ts
+++ b/codegen/crm/objects/leads/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/meetings/http/http.ts
+++ b/codegen/crm/objects/meetings/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/notes/http/http.ts
+++ b/codegen/crm/objects/notes/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/postal_mail/http/http.ts
+++ b/codegen/crm/objects/postal_mail/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/tasks/http/http.ts
+++ b/codegen/crm/objects/tasks/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/objects/taxes/http/http.ts
+++ b/codegen/crm/objects/taxes/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/owners/http/http.ts
+++ b/codegen/crm/owners/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/pipelines/http/http.ts
+++ b/codegen/crm/pipelines/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/products/http/http.ts
+++ b/codegen/crm/products/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/properties/http/http.ts
+++ b/codegen/crm/properties/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/quotes/http/http.ts
+++ b/codegen/crm/quotes/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/schemas/http/http.ts
+++ b/codegen/crm/schemas/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/tickets/http/http.ts
+++ b/codegen/crm/tickets/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/crm/timeline/http/http.ts
+++ b/codegen/crm/timeline/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/events/http/http.ts
+++ b/codegen/events/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/events/send/http/http.ts
+++ b/codegen/events/send/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/files/http/http.ts
+++ b/codegen/files/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/marketing/emails/http/http.ts
+++ b/codegen/marketing/emails/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/marketing/events/http/http.ts
+++ b/codegen/marketing/events/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/marketing/forms/http/http.ts
+++ b/codegen/marketing/forms/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/marketing/transactional/http/http.ts
+++ b/codegen/marketing/transactional/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/oauth/http/http.ts
+++ b/codegen/oauth/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/settings/business_units/http/http.ts
+++ b/codegen/settings/business_units/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/settings/users/http/http.ts
+++ b/codegen/settings/users/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 

--- a/codegen/webhooks/http/http.ts
+++ b/codegen/webhooks/http/http.ts
@@ -3,6 +3,7 @@ import  FormData from "form-data";
 import { URL, URLSearchParams } from 'url';
 import * as http from 'http';
 import * as https from 'https';
+import type { Readable } from 'stream';
 import { Observable, from } from '../rxjsStub';
 
 export * from './isomorphic-fetch';
@@ -26,7 +27,7 @@ export enum HttpMethod {
  * Represents an HTTP file which will be transferred from or to a server.
  */
 export type HttpFile = {
-    data: Buffer,
+    data: Buffer | Readable,
     name: string
 };
 


### PR DESCRIPTION
## Summary

- Widen `HttpFile.data` to `Buffer | Readable` (Node `stream`) in every `[codegen/**/http/http.ts](codegen)` copy.
- Add `import type { Readable } from 'stream'` next to existing Node imports.

## Why

- TypeScript rejects valid usage when passing `fs.createReadStream(...)` (a `ReadStream` / `Readable`) because `HttpFile` only allowed `Buffer`.
- Multipart uploads already pass `file.data` through `form-data` `append()`, which accepts streams at runtime; types were narrower than behavior and than README examples.

## Related issues

Fixes #468