### PR TITLE
chore: bump version to 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/HubSpot/hubspot-api-nodejs/compare/13.5.0...HEAD)
+## [Unreleased](https://github.com/HubSpot/hubspot-api-nodejs/compare/14.0.0...HEAD)
+
+## [14.0.0] - 2026-06-30
+
+## Breaking Changes
+
+- Minimum required Node.js version raised from 18 to 22.
+- Replaced `node-fetch` dependency with native Node.js `fetch`.
 
 ## [13.5.0] - 2026-03-19
 
@@ -1156,3 +1163,4 @@ export enum Enum {
 [13.3.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/13.3.0
 [13.4.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/13.4.0
 [13.5.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/13.5.0
+[14.0.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/14.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/api-client",
-  "version": "13.5.0",
+  "version": "14.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/api-client",
-      "version": "13.5.0",
+      "version": "14.0.0",
       "license": "ISC",
       "dependencies": {
         "@types/node": "*",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,5 @@
   "bugs": {
     "url": "https://github.com/HubSpot/hubspot-api-nodejs/issues"
   },
-  "homepage": "https://github.com/HubSpot/hubspot-api-nodejs#readme",
-  "allowScripts": {
-    "unrs-resolver@1.7.2": true
-  }
+  "homepage": "https://github.com/HubSpot/hubspot-api-nodejs#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/api-client",
-  "version": "13.5.0",
+  "version": "14.0.0",
   "description": "NodeJS v3 [HubSpot API](https://developers.hubspot.com/docs/api/overview) SDK(Client) files",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -64,5 +64,8 @@
   "bugs": {
     "url": "https://github.com/HubSpot/hubspot-api-nodejs/issues"
   },
-  "homepage": "https://github.com/HubSpot/hubspot-api-nodejs#readme"
+  "homepage": "https://github.com/HubSpot/hubspot-api-nodejs#readme",
+  "allowScripts": {
+    "unrs-resolver@1.7.2": true
+  }
 }


### PR DESCRIPTION
## Summary

- Bump version to `14.0.0`
- Update `CHANGELOG.md` with breaking changes for this release

## Breaking Changes in 14.0.0

- Minimum required Node.js version raised from 18 to 22 (Node 18 is EOL)
- Replaced `node-fetch` dependency with native Node.js `fetch`
