### PR TITLE
chore: bump version to 14.0.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/HubSpot/hubspot-api-nodejs/compare/14.0.0...HEAD)
+## [Unreleased](https://github.com/HubSpot/hubspot-api-nodejs/compare/14.0.1...HEAD)
+
+## [14.0.1] - 2026-07-01
+
+## Fixed
+
+- Fixed global middleware merge behavior in `ObservableAPI` clients. Configuration-level middleware was being dropped instead of preserved when no call-time `_options.middleware` was passed.
 
 ## [14.0.0] - 2026-06-30
 
@@ -1164,3 +1170,4 @@ export enum Enum {
 [13.4.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/13.4.0
 [13.5.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/13.5.0
 [14.0.0]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/14.0.0
+[14.0.1]: https://github.com/HubSpot/hubspot-api-nodejs/releases/tag/14.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/api-client",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/api-client",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "license": "ISC",
       "dependencies": {
         "@types/node": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/api-client",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "NodeJS v3 [HubSpot API](https://developers.hubspot.com/docs/api/overview) SDK(Client) files",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Bumping the package to 14.0.1 in anticipation of releasing the middleware fix.